### PR TITLE
Strigify Enum Outputs

### DIFF
--- a/Excel_UI/IO/InOutHelp.cs
+++ b/Excel_UI/IO/InOutHelp.cs
@@ -44,14 +44,9 @@ namespace BH.UI.Excel
 
         public static object ReturnTypeHelper(this object obj)
         {
-            if (obj == null)
-                return ExcelError.ExcelErrorNull;
-            else if (obj.GetType().IsPrimitive || obj is string)
-                return obj;
-            else if (obj is Guid)
-                return obj.ToString();
-            else
-                return obj.GetType().ToText() + " [" + Project.ActiveProject.IAdd(obj) + "]";
+            var acc = new Templates.FormulaDataAccessor();
+            acc.SetDataItem(0, obj);
+            return acc.GetOutput();
         }
 
         /*****************************************************************/

--- a/Excel_UI/Methods/Properties.cs
+++ b/Excel_UI/Methods/Properties.cs
@@ -63,15 +63,8 @@ namespace BH.UI.Excel
 
             //Get the object
             List<object> objs = _objectIds.Select(x => {
-                string str = x as string;
-                int start = str.LastIndexOf("[");
-                int end = str.LastIndexOf("]");
-                if(start != -1 && end != -1 && end > start)
-                {
-                    start++;
-                    return Project.ActiveProject.GetAny(str.Substring(start, end - start));
-                }
-                return x;
+                var obj = Project.ActiveProject.GetAny(x.ToString());
+                return obj == null ? x : obj;
             }).ToList();
 
             if (objs == null)

--- a/Excel_UI/Methods/Properties.cs
+++ b/Excel_UI/Methods/Properties.cs
@@ -45,6 +45,7 @@ namespace BH.UI.Excel
                 [ExcelArgument(Name = "Include the name of the properties")] bool includePropertyNames = false,
                 [ExcelArgument(Name = "Explode inner objects")] bool goDeep = false)
         {
+            Compute.ClearCurrentEvents();
 
             object[] _objectIds = new object[] { };
             if (objectIds is object[,])

--- a/Excel_UI/UI/Templates/FormulaDataAccessor.cs
+++ b/Excel_UI/UI/Templates/FormulaDataAccessor.cs
@@ -179,6 +179,10 @@ namespace BH.UI.Excel.Templates
                 {
                     return SetDataItem(index, (data as IEnumerable).Cast<object>().ToList());
                 }
+                if (data.GetType().IsEnum)
+                {
+                    return SetDataItem(index, Enum.GetName(data.GetType(), data));
+                }
                 return SetDataItem(index,
                     data.GetType().ToText() + " [" + Project.ActiveProject.IAdd(data) + "]"
                 );


### PR DESCRIPTION
Fixes #25 

Been sitting on this for a while due to the following caveat: This will mean Enums don't work when passed as an `Object` parameter (they will be left as strings).

Thinking about it though there isn't much of a use-case for that so the benefits seem to outweigh the negative. The only thing that springs to mind is `SetProperty` and it may be that we could put in some code to allow for strings to be implicitly converted when passed to `SetProperty` when the property is an Enum. I have a local change for this that I will raise against `BHoM_Engine` for this, under the pretext that it's a proposal and may be rejected if there is a good reason to.