### PR TITLE
Implement ValueList Caller to use Excel DataValidation

### DIFF
--- a/Excel_UI/Addin/AddIn.cs
+++ b/Excel_UI/Addin/AddIn.cs
@@ -221,7 +221,7 @@ namespace BH.UI.Excel
             {
                 CallerFormula formula = m_formulea[e.CallerType.Name];
                 formula.Caller.SetItem(e.SelectedItem);
-                formula.Caller.Run();
+                formula.Run();
             }
         }
 

--- a/Excel_UI/Excel_UI.csproj
+++ b/Excel_UI/Excel_UI.csproj
@@ -110,7 +110,10 @@
     <Compile Include="UI\Components\Engine\Query.cs" />
     <Compile Include="UI\Components\Engine\SetProperty.cs" />
     <Compile Include="UI\Components\Engine\ToJson.cs" />
+    <Compile Include="UI\Components\oM\CreateData.cs" />
+    <Compile Include="UI\Templates\CallerValueListFormula.cs" />
     <Compile Include="UI\Components\oM\CreateDictionary.cs" />
+    <Compile Include="UI\Components\oM\CreateEnum.cs" />
     <Compile Include="UI\Components\oM\CreateObject.cs" />
     <Compile Include="UI\Components\oM\CreateType.cs" />
     <Compile Include="UI\Global\FormulaSearchMenu.cs" />

--- a/Excel_UI/UI/Components/oM/CreateData.cs
+++ b/Excel_UI/UI/Components/oM/CreateData.cs
@@ -1,0 +1,71 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.Engine.Reflection;
+using BH.UI.Components;
+using BH.UI.Excel.Templates;
+using BH.UI.Templates;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BH.UI.Excel.Components
+{
+    public class CreateDataFormula : CallerValueListFormula
+    {
+        /*******************************************/
+        /**** Properties                        ****/
+        /*******************************************/
+
+        public override string Name {
+            get {
+                return "CreateData." + Caller.Name;
+            }
+        }
+        public override Caller Caller { get; } = new CreateDataCaller();
+
+        public override string MenuRoot { get; } = "Create Data";
+
+        public override string Function => Name;
+
+        /*******************************************/
+        /**** Constructors                      ****/
+        /*******************************************/
+
+        public CreateDataFormula(FormulaDataAccessor accessor) : base(accessor) { }
+
+        protected override List<string> GetChoices()
+        {
+            var dataAccessor = new FormulaDataAccessor();
+            var names = MultiChoiceCaller.GetChoiceNames();
+            return MultiChoiceCaller.Choices.Select((o, i) =>
+            {
+                dataAccessor.SetDataItem(0, o);
+                string output = dataAccessor.GetOutput().ToString();
+                int brkt = output.LastIndexOf("[");
+                return names[i] + " " + output.Substring(brkt);
+            }).ToList();
+        }
+    }
+}

--- a/Excel_UI/UI/Components/oM/CreateEnum.cs
+++ b/Excel_UI/UI/Components/oM/CreateEnum.cs
@@ -1,0 +1,69 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.Engine.Reflection;
+using BH.UI.Components;
+using BH.UI.Excel.Templates;
+using BH.UI.Templates;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BH.UI.Excel.Components
+{
+    public class CreateEnumFormula : CallerValueListFormula
+    {
+        /*******************************************/
+        /**** Properties                        ****/
+        /*******************************************/
+
+        public override string Name {
+            get {
+                Type t = Caller.SelectedItem as Type;
+                if (t != null)
+                {
+                    return "CreateEnum." + t.Namespace.Split('.').Last() + "." + t.ToText();
+                }
+                return base.Name;
+            }
+        }
+
+        public override Caller Caller { get; } = new CreateEnumCaller();
+
+        public override string MenuRoot { get; } = "Create Enum";
+
+        public override string Function => Name;
+
+        /*******************************************/
+        /**** Constructors                      ****/
+        /*******************************************/
+
+        public CreateEnumFormula(FormulaDataAccessor accessor) : base(accessor) { }
+
+        protected override List<string> GetChoices()
+        {
+            return MultiChoiceCaller.GetChoiceNames();
+        }
+    }
+}

--- a/Excel_UI/UI/Templates/CallerFormula.cs
+++ b/Excel_UI/UI/Templates/CallerFormula.cs
@@ -122,7 +122,7 @@ namespace BH.UI.Excel.Templates
         /**** Private Methods                   ****/
         /*******************************************/
 
-        private void Caller_ItemSelected(object sender, object e)
+        protected virtual void Caller_ItemSelected(object sender, object e)
         {
             Range cell = Application.Selection as Range;
             var cellcontents = "=" + Function;
@@ -136,6 +136,14 @@ namespace BH.UI.Excel.Templates
                 if (cell != null) cell.Formula = cellcontents;
                 Application.SendKeys("{F2}{(}", true);
             }
+        }
+
+
+        /*******************************************/
+
+        public virtual bool Run()
+        {
+            return Caller.Run();
         }
 
         /*******************************************/

--- a/Excel_UI/UI/Templates/CallerValueListFormula.cs
+++ b/Excel_UI/UI/Templates/CallerValueListFormula.cs
@@ -64,8 +64,11 @@ namespace BH.UI.Excel.Templates
                         Range cell = app.Range[reftext];
                         cell.Value = options.FirstOrDefault();
                         cell.Validation.Delete();
-                        cell.Validation.Add(XlDVType.xlValidateList, Formula1: options.Aggregate((a, b) => $"{a}, {b}"));
-                        cell.Validation.IgnoreBlank = true;
+                        if (options.Count > 0)
+                        {
+                            cell.Validation.Add(XlDVType.xlValidateList, Formula1: options.Aggregate((a, b) => $"{a}, {b}"));
+                            cell.Validation.IgnoreBlank = true;
+                        }
                         if (!proj.Empty) proj.SaveData(workbook);
                     });
                     Caller.DataAccessor.SetDataItem(0, "");

--- a/Excel_UI/UI/Templates/CallerValueListFormula.cs
+++ b/Excel_UI/UI/Templates/CallerValueListFormula.cs
@@ -50,7 +50,9 @@ namespace BH.UI.Excel.Templates
             var options = GetChoices();
 
             var app = ExcelDnaUtil.Application as Application;
+            var workbook = app.ActiveWorkbook;
 
+            var proj = Project.ForIDs(options);
             try
             {
                 ExcelReference xlref = XlCall.Excel(XlCall.xlfCaller) as ExcelReference;
@@ -64,6 +66,7 @@ namespace BH.UI.Excel.Templates
                         cell.Validation.Delete();
                         cell.Validation.Add(XlDVType.xlValidateList, Formula1: options.Aggregate((a, b) => $"{a}, {b}"));
                         cell.Validation.IgnoreBlank = true;
+                        if (!proj.Empty) proj.SaveData(workbook);
                     });
                     Caller.DataAccessor.SetDataItem(0, "");
                     return true;

--- a/Excel_UI/UI/Templates/CallerValueListFormula.cs
+++ b/Excel_UI/UI/Templates/CallerValueListFormula.cs
@@ -1,0 +1,86 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.Engine.Reflection;
+using BH.UI.Templates;
+using ExcelDna.Integration;
+using Microsoft.Office.Interop.Excel;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace BH.UI.Excel.Templates
+{
+    public abstract class CallerValueListFormula : CallerFormula
+    {
+        public MultiChoiceCaller MultiChoiceCaller
+        {
+            get
+            {
+                return Caller as MultiChoiceCaller;
+            }
+        }
+
+        public CallerValueListFormula(FormulaDataAccessor accessor) : base(accessor)
+        {
+
+        }
+
+        public override bool Run()
+        {
+            var options = GetChoices();
+
+            var app = ExcelDnaUtil.Application as Application;
+
+            try
+            {
+                ExcelReference xlref = XlCall.Excel(XlCall.xlfCaller) as ExcelReference;
+                if (xlref != null)
+                {
+                    var reftext = XlCall.Excel(XlCall.xlfReftext, xlref, true);
+                    ExcelAsyncUtil.QueueAsMacro(() =>
+                    {
+                        Range cell = app.Range[reftext];
+                        cell.Value = options.FirstOrDefault();
+                        cell.Validation.Delete();
+                        cell.Validation.Add(XlDVType.xlValidateList, Formula1: options.Aggregate((a, b) => $"{a}, {b}"));
+                        cell.Validation.IgnoreBlank = true;
+                    });
+                    Caller.DataAccessor.SetDataItem(0, "");
+                    return true;
+                }
+            } catch (Exception e)
+            {
+                Compute.RecordError(e.GetType().ToText() + ": " + e.Message);
+            }
+            return false;
+        }
+        
+        protected abstract List<string> GetChoices();
+
+        protected override void Caller_ItemSelected(object sender, object e)
+        {
+            Range cell = Application.Selection as Range;
+            cell.Formula = "=" + Function + "()";
+        }
+    }
+}

--- a/Excel_UI/UI/Templates/FormulaDataAccessor.cs
+++ b/Excel_UI/UI/Templates/FormulaDataAccessor.cs
@@ -166,7 +166,7 @@ namespace BH.UI.Excel.Templates
         {
             try
             {
-                if (data.GetType().IsPrimitive || data is string)
+                if (data.GetType().IsPrimitive || data is string || data is object[,])
                 {
                     output = data;
                     return true;

--- a/Excel_UI/UI/Templates/SelectorMenu_CommandBar.cs
+++ b/Excel_UI/UI/Templates/SelectorMenu_CommandBar.cs
@@ -82,14 +82,11 @@ namespace BH.UI.Excel.Templates
                 {
                     T method = tree.Value;
                     CommandBarButton methodItem = AppendMenuItem(menu, tree.Name, Item_Click);
-                    try
-                    {
-                        methodItem.Tag = Engine.Reflection.Convert.ToText(method as dynamic, true);
-                    }
-                    catch { }
+                    methodItem.Tag = Guid.NewGuid().ToString();
                     m_ItemLinks[methodItem.Tag] = method;
                 }
-            } catch (Exception e)
+            }
+            catch (Exception e)
             {
                 Compute.RecordError(e.Message);
             }


### PR DESCRIPTION
Fixes #23 

This uses Excel Data Validation when run to provide the user with a list of options for `MultiChoiceCaller` (`CreateEnumCaller` and `CreateDataCaller`).

Works reasonably nicely though there are some limitations:

- The formula can't persist in the cell, it is replaced by a value and the validation is added to the cell. So it's more of a one-shot utility function.
- Currently with `CreateData` the objects in the list do not persist across save, close, reopen as they are not serialised. This will need to be addressed before approval at a minimum. Since the formula is gone `Ctrl`+`Alt`+`F9` will not bring them back as it will with formula. Simplest solution would be to serialise them along with the rest but the serialisation/internalisation feature is under discussion in #55 so could change.

Conflict: `Excel_UI.csproj` will conflict with that of #60, so when one of these merges the other will need for me to rebase atop it and resolve that conflict (it's a simple keep both sides deal). 
![image](https://user-images.githubusercontent.com/18450341/51174651-34c2c080-18b0-11e9-8e1b-c37d683a9ca6.png)

This feels a lot more consistent when used in conjunction with #61 but neither are dependent on the other and work independently, hence keeping the PRs separate and single-purpose.