### PR TITLE
Excel_Toolkit: Treat empty cells in ranges as default for type for List inputs

### DIFF
--- a/Excel_Engine/Excel_Engine.csproj
+++ b/Excel_Engine/Excel_Engine.csproj
@@ -61,6 +61,7 @@
     <Compile Include="Convert\ToExcel\Reference.cs" />
     <Compile Include="Convert\ToExcel\DateTime.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Query\CleanList.cs" />
     <Compile Include="Query\TextRef.cs" />
     <Compile Include="Query\Caller.cs" />
   </ItemGroup>

--- a/Excel_Engine/Query/CleanList.cs
+++ b/Excel_Engine/Query/CleanList.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using BH.oM.Excel;
+using ExcelDna.Integration;
+
+namespace BH.Engine.Excel
+{
+    public static partial class Query
+    {
+        public static List<T> CleanList<T>(List<T> list)
+        {
+            return list.FindAll(item => item != null);
+        }
+    }
+}

--- a/Excel_UI/UI/Templates/FormulaDataAccessor.cs
+++ b/Excel_UI/UI/Templates/FormulaDataAccessor.cs
@@ -99,10 +99,10 @@ namespace BH.UI.Excel.Templates
                 List<T> list = new List<T>();
                 foreach (object o in item as IEnumerable)
                 {
-                    if (!IsBlankOrError<T>(o))
-                    {
+                    if (IsBlankOrError<T>(o))
+                        list.Add(default(T));
+                    else
                         list.Add((T)(o as dynamic));
-                    }
                 }
                 return list;
             }
@@ -142,10 +142,10 @@ namespace BH.UI.Excel.Templates
                     for (int j = 0; j < height; j++)
                     {
                         object o = (item as object[,])[j, i];
-                        if (!IsBlankOrError<T>(o))
-                        {
+                        if (IsBlankOrError<T>(o))
+                            list[i].Add(default(T));
+                        else
                             list[i].Add((T)(o as dynamic));
-                        }
                     }
                 }
                 return list;


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #46 

<!-- Add short description of what has been fixed -->
Treats empty cells in ranges as `default(T)`. Also adds an engine method, `CleanList` that removes nulls from a list of objects, for use when you want just the non-blank cells from a sparse or partially populated range.


### Test files
<!-- Link to test files to validate the proposed changes -->
[Excel_Toolkit-issue46-DefaultEmpties.xlsx](https://github.com/BHoM/Excel_Toolkit/files/3166120/Excel_Toolkit-issue46-DefaultEmpties.xlsx)


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->
NOTE: this may break existing Excel files that rely on the previous behaviour of only populating the non-blank cells.