### PR TITLE
Use more complete namespaces for Formula names

### DIFF
--- a/Excel_UI/UI/Components/oM/CreateObject.cs
+++ b/Excel_UI/UI/Components/oM/CreateObject.cs
@@ -51,7 +51,7 @@ namespace BH.UI.Excel.Components
                     Type decltype = (Caller as MethodCaller).OutputParams.First().DataType;
                     string ns = decltype.Namespace;
                     if (ns.StartsWith("BH")) ns = ns.Split('.').Skip(2).Aggregate((a, b) => $"{a}.{b}");
-                    return decltype.Name + "." + ns + "." + Caller.Name;
+                    return "Create." + ns + "." + Caller.Name;
                 }
                 return Category + "." + Caller.Name;
             }

--- a/Excel_UI/UI/Components/oM/CreateObject.cs
+++ b/Excel_UI/UI/Components/oM/CreateObject.cs
@@ -42,6 +42,21 @@ namespace BH.UI.Excel.Components
 
         public override string MenuRoot { get; } = "Create Object";
 
+        public override string Name
+        {
+            get
+            {
+                if (Caller is MethodCaller && Caller.SelectedItem != null)
+                {
+                    Type decltype = (Caller as MethodCaller).OutputParams.First().DataType;
+                    string ns = decltype.Namespace;
+                    if (ns.StartsWith("BH")) ns = ns.Split('.').Skip(2).Aggregate((a, b) => $"{a}.{b}");
+                    return decltype.Name + "." + ns + "." + Caller.Name;
+                }
+                return Category + "." + Caller.Name;
+            }
+        }
+
         /*******************************************/
         /**** Constructors                      ****/
         /*******************************************/

--- a/Excel_UI/UI/Templates/CallerFormula.cs
+++ b/Excel_UI/UI/Templates/CallerFormula.cs
@@ -46,7 +46,9 @@ namespace BH.UI.Excel.Templates
                 if (Caller is MethodCaller && Caller.SelectedItem != null)
                 {
                     Type decltype = (Caller as MethodCaller).Method.DeclaringType;
-                    return decltype.Name + "." + decltype.Namespace.Split('.').Last() + "." + Caller.Name;
+                    string ns = decltype.Namespace;
+                    if (ns.StartsWith("BH")) ns = ns.Split('.').Skip(2).Aggregate((a, b) => $"{a}.{b}");
+                    return decltype.Name + "." + ns + "." + Caller.Name;
                 }
                 return Category + "." + Caller.Name;
             }


### PR DESCRIPTION
#### WARNING: Breaks existing Excel documents if they use affected methods


<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #94

Uses the full namespace bar the `BH.oM.`/`BH.Engine.`/`BH.Adapter.` at the start.

In the case of a Create method it uses the namespace of the resulting type, not the engine method (this matches Grasshopper and the menu structure). e.g. `Create.Structure.Elements.Bar` instead of `Create.Structure.Bar` due to the engine method being `BH.Engine.Structure.Create.Bar` and not `BH.Engine.Structure.Elements.Create.Bar`.

### Test files
N/A Have a look at the registered formulae or see what is placed in the cell when picking from a menu. The above example of `Create.Structure.Elements.Bar` is one, it is `Create.Structure.Bar` on `master`


### Changelog

#### Fixed
- Namespace for formulae only taking the last part of the namespace.


### Additional comments
<!-- As required -->
#### WARNING: Breaks existing Excel documents if they use affected methods