### PR TITLE
Excel toolkit issue85 startup performance

### DIFF
--- a/Excel_Engine/Excel_Engine.csproj
+++ b/Excel_Engine/Excel_Engine.csproj
@@ -55,12 +55,15 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Compute\Note.cs" />
+    <Compile Include="Timer.cs" />
     <Compile Include="Compute\NumberFormat.cs" />
     <Compile Include="Create\Reference.cs" />
     <Compile Include="Convert\FromExcel\Reference.cs" />
     <Compile Include="Convert\ToExcel\Reference.cs" />
     <Compile Include="Convert\ToExcel\DateTime.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Query\GetMeanTime.cs" />
+    <Compile Include="Query\GetTotalTime.cs" />
     <Compile Include="Query\CleanList.cs" />
     <Compile Include="Query\TextRef.cs" />
     <Compile Include="Query\Caller.cs" />

--- a/Excel_Engine/Query/GetMeanTime.cs
+++ b/Excel_Engine/Query/GetMeanTime.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using BH.oM.Excel;
+using ExcelDna.Integration;
+
+namespace BH.Engine.Excel.Profiling
+
+{
+    public static partial class Query
+    {
+        public static double GetMeanTime(string name)
+        {
+            return Timer.GetMean(name);
+        }
+    }
+}

--- a/Excel_Engine/Query/GetTotalTime.cs
+++ b/Excel_Engine/Query/GetTotalTime.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using BH.oM.Excel;
+using ExcelDna.Integration;
+
+namespace BH.Engine.Excel.Profiling
+
+{
+    public static partial class Query
+    {
+        public static double GetTotalTime(string name)
+        {
+            return Timer.GetTotal(name);
+        }
+    }
+}

--- a/Excel_Engine/Timer.cs
+++ b/Excel_Engine/Timer.cs
@@ -1,0 +1,57 @@
+﻿using ExcelDna.Integration;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BH.Engine.Excel.Profiling
+{
+    public class Timer : IDisposable
+    {
+        public Timer(string name)
+        {
+            m_name = name;
+            m_start = DateTime.Now;
+        }
+
+        private string m_name;
+        private DateTime m_start;
+        
+        private static Dictionary<string, List<double>> records = new Dictionary<string, List<double>>();
+
+        private static void RecordTime(string name, double time)
+        {
+            if (records.ContainsKey(name))
+            {
+                records[name].Add(time);
+            } else
+            {
+                records.Add(name, new List<double> { time });
+            }
+        }
+
+        public static double GetTotal(string name)
+        {
+            if(records.ContainsKey(name))
+            {
+                return records[name].Sum();
+            }
+            return 0;
+        }
+
+        public static double GetMean(string name)
+        {
+            if(records.ContainsKey(name) && records[name].Count > 0)
+            {
+                return records[name].Sum() / records[name].Count;
+            }
+            return 0;
+        }
+
+        public void Dispose()
+        {
+            RecordTime(m_name, (DateTime.Now - m_start).TotalMilliseconds);
+        }
+    }
+}

--- a/Excel_UI/Addin/AddIn.cs
+++ b/Excel_UI/Addin/AddIn.cs
@@ -117,6 +117,8 @@ namespace BH.UI.Excel
 
         private void App_WorkbookOpen(Workbook Wb)
         {
+            foreach (var caller in m_formulea) caller.Value.AddToMenu();
+
             List<string> json = new List<string>();
             _Worksheet newsheet;
             try

--- a/Excel_UI/Addin/AddIn.cs
+++ b/Excel_UI/Addin/AddIn.cs
@@ -72,8 +72,14 @@ namespace BH.UI.Excel
                 ExcelDna.Logging.LogDisplay.Hide();
 
             var app = ExcelDnaUtil.Application as Application;
+            app.WorkbookActivate += App_WorkbookActivate;
             app.WorkbookOpen += App_WorkbookOpen;
             ExcelDna.IntelliSense.IntelliSenseServer.Install();
+        }
+
+        private void App_WorkbookActivate(Workbook Wb)
+        {
+            foreach (var caller in m_formulea) caller.Value.AddToMenu();
         }
 
         private void AddInternalise()
@@ -117,8 +123,6 @@ namespace BH.UI.Excel
 
         private void App_WorkbookOpen(Workbook Wb)
         {
-            foreach (var caller in m_formulea) caller.Value.AddToMenu();
-
             List<string> json = new List<string>();
             _Worksheet newsheet;
             try

--- a/Excel_UI/Addin/AddIn.cs
+++ b/Excel_UI/Addin/AddIn.cs
@@ -57,11 +57,7 @@ namespace BH.UI.Excel
         {
             m_menus = new List<CommandBar>();
 
-            foreach (CommandBar commandBar in (ExcelDnaUtil.Application as Application).CommandBars)
-            {
-                if (commandBar.Name == "Cell" || commandBar.Name.Contains("List Range"))
-                    m_menus.Add(commandBar);
-            }
+            m_menus.Add((ExcelDnaUtil.Application as Application).CommandBars["Cell"]);
 
             RegisterExcelMethods();
             RegisterBHoMMethods();
@@ -72,14 +68,8 @@ namespace BH.UI.Excel
                 ExcelDna.Logging.LogDisplay.Hide();
 
             var app = ExcelDnaUtil.Application as Application;
-            app.WorkbookActivate += App_WorkbookActivate;
             app.WorkbookOpen += App_WorkbookOpen;
             ExcelDna.IntelliSense.IntelliSenseServer.Install();
-        }
-
-        private void App_WorkbookActivate(Workbook Wb)
-        {
-            foreach (var caller in m_formulea) caller.Value.AddToMenu();
         }
 
         private void AddInternalise()

--- a/Excel_UI/Addin/AddIn.cs
+++ b/Excel_UI/Addin/AddIn.cs
@@ -55,21 +55,24 @@ namespace BH.UI.Excel
 
         public void AutoOpen()
         {
-            m_menus = new List<CommandBar>();
+            using (Engine.Excel.Profiling.Timer timer = new Engine.Excel.Profiling.Timer("open"))
+            {
+                m_menus = new List<CommandBar>();
 
-            m_menus.Add((ExcelDnaUtil.Application as Application).CommandBars["Cell"]);
+                m_menus.Add((ExcelDnaUtil.Application as Application).CommandBars["Cell"]);
 
-            RegisterExcelMethods();
-            RegisterBHoMMethods();
-            AddInternalise();
+                RegisterExcelMethods();
+                RegisterBHoMMethods();
+                AddInternalise();
 
-            //Hide error box showing methods not working properly
-            if (!DebugConfig.ShowExcelDNALog)
-                ExcelDna.Logging.LogDisplay.Hide();
+                //Hide error box showing methods not working properly
+                if (!DebugConfig.ShowExcelDNALog)
+                    ExcelDna.Logging.LogDisplay.Hide();
 
-            var app = ExcelDnaUtil.Application as Application;
-            app.WorkbookOpen += App_WorkbookOpen;
-            ExcelDna.IntelliSense.IntelliSenseServer.Install();
+                var app = ExcelDnaUtil.Application as Application;
+                app.WorkbookOpen += App_WorkbookOpen;
+                ExcelDna.IntelliSense.IntelliSenseServer.Install();
+            }
         }
 
         private void AddInternalise()

--- a/Excel_UI/UI/Components/Adapter/CreateAdapter.cs
+++ b/Excel_UI/UI/Components/Adapter/CreateAdapter.cs
@@ -48,7 +48,7 @@ namespace BH.UI.Excel.Components
         /**** Constructors                      ****/
         /*******************************************/
 
-        public CreateAdapterFormula(FormulaDataAccessor accessor, List<CommandBar> ctxMenus) : base(accessor, ctxMenus) {
+        public CreateAdapterFormula(FormulaDataAccessor accessor) : base(accessor) {
         }
     }
 }

--- a/Excel_UI/UI/Components/Adapter/CreateQuery.cs
+++ b/Excel_UI/UI/Components/Adapter/CreateQuery.cs
@@ -46,7 +46,7 @@ namespace BH.UI.Excel.Components
         /**** Constructors                      ****/
         /*******************************************/
 
-        public CreateQueryFormula(FormulaDataAccessor accessor, List<CommandBar> ctxMenus) : base(accessor, ctxMenus) { }
+        public CreateQueryFormula(FormulaDataAccessor accessor) : base(accessor) { }
 
         /*******************************************/
     }

--- a/Excel_UI/UI/Components/Adapter/Delete.cs
+++ b/Excel_UI/UI/Components/Adapter/Delete.cs
@@ -44,7 +44,7 @@ namespace BH.UI.Excel.Components
         /**** Constructors                      ****/
         /*******************************************/
 
-        public DeleteFormula(FormulaDataAccessor accessor, List<CommandBar> ctxMenus) : base(accessor, ctxMenus) { }
+        public DeleteFormula(FormulaDataAccessor accessor) : base(accessor) { }
 
         /*******************************************/
     }

--- a/Excel_UI/UI/Components/Adapter/Execute.cs
+++ b/Excel_UI/UI/Components/Adapter/Execute.cs
@@ -44,7 +44,7 @@ namespace BH.UI.Excel.Components
         /**** Constructors                      ****/
         /*******************************************/
 
-        public ExecuteFormula(FormulaDataAccessor accessor, List<CommandBar> ctxMenus) : base(accessor, ctxMenus) { }
+        public ExecuteFormula(FormulaDataAccessor accessor) : base(accessor) { }
 
         /*******************************************/
     }

--- a/Excel_UI/UI/Components/Adapter/Move.cs
+++ b/Excel_UI/UI/Components/Adapter/Move.cs
@@ -46,7 +46,7 @@ namespace BH.UI.Excel.Components
         /**** Constructors                      ****/
         /*******************************************/
 
-        public MoveFormula(FormulaDataAccessor accessor, List<CommandBar> ctxMenus) : base(accessor, ctxMenus) { }
+        public MoveFormula(FormulaDataAccessor accessor) : base(accessor) { }
 
         /*******************************************/
     }

--- a/Excel_UI/UI/Components/Adapter/Pull.cs
+++ b/Excel_UI/UI/Components/Adapter/Pull.cs
@@ -44,7 +44,7 @@ namespace BH.UI.Excel.Components
         /**** Constructors                      ****/
         /*******************************************/
 
-        public PullFormula(FormulaDataAccessor accessor, List<CommandBar> ctxMenus) : base(accessor, ctxMenus) { }
+        public PullFormula(FormulaDataAccessor accessor) : base(accessor) { }
 
         /*******************************************/
     }

--- a/Excel_UI/UI/Components/Adapter/Push.cs
+++ b/Excel_UI/UI/Components/Adapter/Push.cs
@@ -42,7 +42,7 @@ namespace BH.UI.Excel.Components
         /**** Constructors                      ****/
         /*******************************************/
 
-        public PushFormula(FormulaDataAccessor accessor, List<CommandBar> ctxMenus) : base(accessor, ctxMenus) { }
+        public PushFormula(FormulaDataAccessor accessor) : base(accessor) { }
 
         /*******************************************/
     }

--- a/Excel_UI/UI/Components/Adapter/UpdateProperty.cs
+++ b/Excel_UI/UI/Components/Adapter/UpdateProperty.cs
@@ -44,7 +44,7 @@ namespace BH.UI.Excel.Components
         /**** Constructors                      ****/
         /*******************************************/
 
-        public UpdatePropertyFormula(FormulaDataAccessor accessor, List<CommandBar> ctxMenus) : base(accessor, ctxMenus) { }
+        public UpdatePropertyFormula(FormulaDataAccessor accessor) : base(accessor) { }
 
         /*******************************************/
     }

--- a/Excel_UI/UI/Components/Engine/Compute.cs
+++ b/Excel_UI/UI/Components/Engine/Compute.cs
@@ -44,7 +44,7 @@ namespace BH.UI.Excel.Components
         /**** Constructors                      ****/
         /*******************************************/
 
-        public ComputeFormula(FormulaDataAccessor accessor, List<CommandBar> ctxMenus) : base(accessor, ctxMenus) { }
+        public ComputeFormula(FormulaDataAccessor accessor) : base(accessor) { }
 
         /*******************************************/
     }

--- a/Excel_UI/UI/Components/Engine/Convert.cs
+++ b/Excel_UI/UI/Components/Engine/Convert.cs
@@ -44,7 +44,7 @@ namespace BH.UI.Excel.Components
         /**** Constructors                      ****/
         /*******************************************/
 
-        public ConvertFormula(FormulaDataAccessor accessor, List<CommandBar> ctxMenus) : base(accessor, ctxMenus) { }
+        public ConvertFormula(FormulaDataAccessor accessor) : base(accessor) { }
 
         /*******************************************/
     }

--- a/Excel_UI/UI/Components/Engine/Explode.cs
+++ b/Excel_UI/UI/Components/Engine/Explode.cs
@@ -47,7 +47,7 @@ namespace BH.UI.Excel.Components
         /**** Constructors                      ****/
         /*******************************************/
 
-        public ExplodeFormula(FormulaDataAccessor accessor, List<CommandBar> ctxMenus) : base(accessor, ctxMenus) { }
+        public ExplodeFormula(FormulaDataAccessor accessor) : base(accessor) { }
 
         /*******************************************/
     }

--- a/Excel_UI/UI/Components/Engine/FromJson.cs
+++ b/Excel_UI/UI/Components/Engine/FromJson.cs
@@ -42,7 +42,7 @@ namespace BH.UI.Excel.Components
         /**** Constructors                      ****/
         /*******************************************/
 
-        public FromJsonFormula(FormulaDataAccessor accessor, List<CommandBar> ctxMenus) : base(accessor, ctxMenus) { }
+        public FromJsonFormula(FormulaDataAccessor accessor) : base(accessor) { }
 
         /*******************************************/
     }

--- a/Excel_UI/UI/Components/Engine/GetInfo.cs
+++ b/Excel_UI/UI/Components/Engine/GetInfo.cs
@@ -42,7 +42,7 @@ namespace BH.UI.Excel.Components
         /**** Constructors                      ****/
         /*******************************************/
 
-        public GetInfoFormula(FormulaDataAccessor accessor, List<CommandBar> ctxMenus) : base(accessor, ctxMenus) { }
+        public GetInfoFormula(FormulaDataAccessor accessor) : base(accessor) { }
 
         /*******************************************/
     }

--- a/Excel_UI/UI/Components/Engine/GetProperty.cs
+++ b/Excel_UI/UI/Components/Engine/GetProperty.cs
@@ -42,7 +42,7 @@ namespace BH.UI.Excel.Components
         /**** Constructors                      ****/
         /*******************************************/
 
-        public GetPropertyFormula(FormulaDataAccessor accessor, List<CommandBar> ctxMenus) : base(accessor, ctxMenus) { }
+        public GetPropertyFormula(FormulaDataAccessor accessor) : base(accessor) { }
 
         /*******************************************/
     }

--- a/Excel_UI/UI/Components/Engine/Modify.cs
+++ b/Excel_UI/UI/Components/Engine/Modify.cs
@@ -44,7 +44,7 @@ namespace BH.UI.Excel.Components
         /**** Constructors                      ****/
         /*******************************************/
 
-        public ModifyFormula(FormulaDataAccessor accessor, List<CommandBar> ctxMenus) : base(accessor, ctxMenus) { }
+        public ModifyFormula(FormulaDataAccessor accessor) : base(accessor) { }
 
         /*******************************************/
     }

--- a/Excel_UI/UI/Components/Engine/Query.cs
+++ b/Excel_UI/UI/Components/Engine/Query.cs
@@ -44,7 +44,7 @@ namespace BH.UI.Excel.Components
         /**** Constructors                      ****/
         /*******************************************/
 
-        public QueryFormula(FormulaDataAccessor accessor, List<CommandBar> ctxMenus) : base(accessor, ctxMenus) { }
+        public QueryFormula(FormulaDataAccessor accessor) : base(accessor) { }
 
         /*******************************************/
     }

--- a/Excel_UI/UI/Components/Engine/SetProperty.cs
+++ b/Excel_UI/UI/Components/Engine/SetProperty.cs
@@ -42,7 +42,7 @@ namespace BH.UI.Excel.Components
         /**** Constructors                      ****/
         /*******************************************/
 
-        public SetPropertyFormula(FormulaDataAccessor accessor, List<CommandBar> ctxMenus) : base(accessor, ctxMenus) { }
+        public SetPropertyFormula(FormulaDataAccessor accessor) : base(accessor) { }
 
         /*******************************************/
     }

--- a/Excel_UI/UI/Components/Engine/ToJson.cs
+++ b/Excel_UI/UI/Components/Engine/ToJson.cs
@@ -42,7 +42,7 @@ namespace BH.UI.Excel.Components
         /**** Constructors                      ****/
         /*******************************************/
 
-        public ToJsonFormula(FormulaDataAccessor accessor, List<CommandBar> ctxMenus) : base(accessor, ctxMenus) { }
+        public ToJsonFormula(FormulaDataAccessor accessor) : base(accessor) { }
 
         /*******************************************/
     }

--- a/Excel_UI/UI/Components/oM/CreateCustom.cs
+++ b/Excel_UI/UI/Components/oM/CreateCustom.cs
@@ -45,7 +45,9 @@ namespace BH.UI.Excel.Components
                 Type t = Caller.SelectedItem as Type;
                 if (t != null)
                 {
-                    return "CreateCustom." + t.Namespace.Split('.').Last() + "." + t.ToText();
+                    string ns = t.Namespace;
+                    if (ns.StartsWith("BH")) ns = ns.Split('.').Skip(2).Aggregate((a, b) => $"{a}.{b}");
+                    return "CreateCustom." + ns + "." + t.ToText();
                 }
                 return base.Name;
             }

--- a/Excel_UI/UI/Components/oM/CreateCustom.cs
+++ b/Excel_UI/UI/Components/oM/CreateCustom.cs
@@ -63,7 +63,7 @@ namespace BH.UI.Excel.Components
         /**** Constructors                      ****/
         /*******************************************/
 
-        public CreateCustomFormula(FormulaDataAccessor accessor, List<CommandBar> ctxMenus) : base(accessor, ctxMenus) { }
+        public CreateCustomFormula(FormulaDataAccessor accessor) : base(accessor) { }
 
         /*******************************************/
     }

--- a/Excel_UI/UI/Components/oM/CreateData.cs
+++ b/Excel_UI/UI/Components/oM/CreateData.cs
@@ -54,7 +54,7 @@ namespace BH.UI.Excel.Components
         /**** Constructors                      ****/
         /*******************************************/
 
-        public CreateDataFormula(FormulaDataAccessor accessor, List<CommandBar> ctxMenus) : base(accessor, ctxMenus) { }
+        public CreateDataFormula(FormulaDataAccessor accessor) : base(accessor) { }
 
         protected override List<string> GetChoices()
         {

--- a/Excel_UI/UI/Components/oM/CreateDictionary.cs
+++ b/Excel_UI/UI/Components/oM/CreateDictionary.cs
@@ -42,7 +42,7 @@ namespace BH.UI.Excel.Components
         /**** Constructors                      ****/
         /*******************************************/
 
-        public CreateDictionaryFormula(FormulaDataAccessor accessor, List<CommandBar> ctxMenus) : base(accessor, ctxMenus) { }
+        public CreateDictionaryFormula(FormulaDataAccessor accessor) : base(accessor) { }
 
         /*******************************************/
     }

--- a/Excel_UI/UI/Components/oM/CreateEnum.cs
+++ b/Excel_UI/UI/Components/oM/CreateEnum.cs
@@ -60,7 +60,7 @@ namespace BH.UI.Excel.Components
         /**** Constructors                      ****/
         /*******************************************/
 
-        public CreateEnumFormula(FormulaDataAccessor accessor, List<CommandBar> ctxMenus) : base(accessor, ctxMenus) { }
+        public CreateEnumFormula(FormulaDataAccessor accessor) : base(accessor) { }
 
         protected override List<string> GetChoices()
         {

--- a/Excel_UI/UI/Components/oM/CreateObject.cs
+++ b/Excel_UI/UI/Components/oM/CreateObject.cs
@@ -50,7 +50,7 @@ namespace BH.UI.Excel.Components
                 if (Caller is MethodCaller && Caller.SelectedItem != null)
                 {
                     Type decltype = (Caller as MethodCaller).OutputParams.First().DataType;
-                    if (decltype.IsSubclassOf(typeof(IObject)))
+                    if (typeof(IObject).IsAssignableFrom(decltype))
                     {
                         string ns = decltype.Namespace;
                         if (ns.StartsWith("BH")) ns = ns.Split('.').Skip(2).Aggregate((a, b) => $"{a}.{b}");

--- a/Excel_UI/UI/Components/oM/CreateObject.cs
+++ b/Excel_UI/UI/Components/oM/CreateObject.cs
@@ -20,6 +20,7 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.oM.Base;
 using BH.UI.Components;
 using BH.UI.Excel.Templates;
 using BH.UI.Templates;
@@ -49,9 +50,14 @@ namespace BH.UI.Excel.Components
                 if (Caller is MethodCaller && Caller.SelectedItem != null)
                 {
                     Type decltype = (Caller as MethodCaller).OutputParams.First().DataType;
-                    string ns = decltype.Namespace;
-                    if (ns.StartsWith("BH")) ns = ns.Split('.').Skip(2).Aggregate((a, b) => $"{a}.{b}");
-                    return "Create." + ns + "." + Caller.Name;
+                    if (decltype.IsSubclassOf(typeof(IObject)))
+                    {
+                        string ns = decltype.Namespace;
+                        if (ns.StartsWith("BH")) ns = ns.Split('.').Skip(2).Aggregate((a, b) => $"{a}.{b}");
+                        return "Create." + ns + "." + Caller.Name;
+                    }
+                    return base.Name;
+
                 }
                 return Category + "." + Caller.Name;
             }

--- a/Excel_UI/UI/Components/oM/CreateObject.cs
+++ b/Excel_UI/UI/Components/oM/CreateObject.cs
@@ -67,6 +67,6 @@ namespace BH.UI.Excel.Components
         /**** Constructors                      ****/
         /*******************************************/
 
-        public CreateObjectFormula(FormulaDataAccessor accessor, List<CommandBar> ctxMenus) : base(accessor, ctxMenus) { }
+        public CreateObjectFormula(FormulaDataAccessor accessor) : base(accessor) { }
     }
 }

--- a/Excel_UI/UI/Components/oM/CreateType.cs
+++ b/Excel_UI/UI/Components/oM/CreateType.cs
@@ -60,7 +60,7 @@ namespace BH.UI.Excel.Components
         /**** Constructors                      ****/
         /*******************************************/
 
-        public CreateTypeFormula(FormulaDataAccessor accessor, List<CommandBar> ctxMenus) : base(accessor, ctxMenus) { }
+        public CreateTypeFormula(FormulaDataAccessor accessor) : base(accessor) { }
 
         /*******************************************/
     }

--- a/Excel_UI/UI/Components/oM/CreateType.cs
+++ b/Excel_UI/UI/Components/oM/CreateType.cs
@@ -43,7 +43,10 @@ namespace BH.UI.Excel.Components
                 Type t = Caller.SelectedItem as Type;
                 if (t != null)
                 {
-                    return "CreateType." + t.Namespace.Split('.').Last() + "." + t.ToText();
+
+                    string ns = t.Namespace;
+                    if (ns.StartsWith("BH")) ns = ns.Split('.').Skip(2).Aggregate((a, b) => $"{a}.{b}");
+                    return "CreateType." + ns + "." + t.ToText();
                 }
                 return base.Name;
             }

--- a/Excel_UI/UI/Global/FormulaSearchMenu.cs
+++ b/Excel_UI/UI/Global/FormulaSearchMenu.cs
@@ -61,25 +61,33 @@ namespace BH.UI.Excel.Global
             Dictionary<string, int> dups = new Dictionary<string, int>();
             foreach(var item in PossibleItems)
             {
-                try
+                using (Engine.Excel.Profiling.Timer timer = new Engine.Excel.Profiling.Timer("CreateDelegates"))
                 {
-                    var proxy = CreateDelegate(item);
-                    if (proxy == null) continue;
-                    var name = proxy.Item2.Name;
-                    if (!dups.ContainsKey(name))
+                    try
                     {
-                        dups.Add(name, 1);
-                        delegates.Add(proxy.Item1);
-                        funcAttrs.Add(proxy.Item2);
-                        argAttrs.Add(proxy.Item3);
+                        var proxy = CreateDelegate(item);
+                        if (proxy == null) continue;
+                        var name = proxy.Item2.Name;
+                        if (!dups.ContainsKey(name))
+                        {
+                            dups.Add(name, 1);
+                            delegates.Add(proxy.Item1);
+                            funcAttrs.Add(proxy.Item2);
+                            argAttrs.Add(proxy.Item3);
+                        }
                     }
-                } catch (Exception e) {
-                    Console.WriteLine(e.Message);
+                    catch (Exception e)
+                    {
+                        Console.WriteLine(e.Message);
+                    }
                 }
             }
             try
             {
-                ExcelIntegration.RegisterDelegates(delegates, funcAttrs.Cast<object>().ToList(), argAttrs);
+                using (Engine.Excel.Profiling.Timer timer = new Engine.Excel.Profiling.Timer("RegisterDelegates"))
+                {
+                    ExcelIntegration.RegisterDelegates(delegates, funcAttrs.Cast<object>().ToList(), argAttrs);
+                }
             } catch
             {
                 return false;

--- a/Excel_UI/UI/Templates/CallerFormula.cs
+++ b/Excel_UI/UI/Templates/CallerFormula.cs
@@ -27,11 +27,7 @@ using Microsoft.Office.Core;
 using Microsoft.Office.Interop.Excel;
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Linq;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace BH.UI.Excel.Templates
 {
@@ -121,22 +117,17 @@ namespace BH.UI.Excel.Templates
                 }
                 Menus.Add(menu);
             }
+
+            foreach (var menu in Menus) Caller.AddToMenu(menu.Controls);
             Caller.ItemSelected += Caller_ItemSelected;
         }
 
-        virtual public void AddToMenu()
+        private void LoadFullMenu(CommandBarButton Ctrl, ref bool CancelDefault)
         {
-            if (!m_addedToMenu)
-            {
-                m_addedToMenu = true;
-
-                ThreadPool.QueueUserWorkItem((o) =>
-                {
-                    Caller.SetItem(null);
-                    foreach (var menu in Menus) Caller.AddToMenu(menu.Controls);
-                });
-            }
+            Ctrl.Delete();
+            CancelDefault = true;
         }
+
         /*******************************************/
         /**** Private Methods                   ****/
         /*******************************************/
@@ -177,6 +168,6 @@ namespace BH.UI.Excel.Templates
         /*******************************************/
 
         private FormulaDataAccessor m_dataAccessor;
-        private bool m_addedToMenu;
+        private CommandBarButton m_lazybtn;
     }
 }

--- a/Excel_UI/UI/Templates/CallerFormula.cs
+++ b/Excel_UI/UI/Templates/CallerFormula.cs
@@ -118,7 +118,11 @@ namespace BH.UI.Excel.Templates
                 Menus.Add(menu);
             }
 
-            foreach (var menu in Menus) Caller.AddToMenu(menu.Controls);
+            using (Engine.Excel.Profiling.Timer timer = new Engine.Excel.Profiling.Timer("AddToMenu"))
+            {
+                foreach (var menu in Menus) Caller.AddToMenu(menu.Controls);
+            }
+
             Caller.ItemSelected += Caller_ItemSelected;
         }
 
@@ -168,6 +172,5 @@ namespace BH.UI.Excel.Templates
         /*******************************************/
 
         private FormulaDataAccessor m_dataAccessor;
-        private CommandBarButton m_lazybtn;
     }
 }

--- a/Excel_UI/UI/Templates/CallerFormula.cs
+++ b/Excel_UI/UI/Templates/CallerFormula.cs
@@ -93,43 +93,6 @@ namespace BH.UI.Excel.Templates
         {
             m_dataAccessor = accessor;
             Caller.SetDataAccessor(m_dataAccessor);
-
-            if (Caller.Selector != null)
-            {
-                var smenu = SelectorMenuUtil.ISetExcelSelectorMenu(Caller.Selector);
-                smenu.RootName = MenuRoot;
-            }
-
-            Application = ExcelDna.Integration.ExcelDnaUtil.Application as Application;
-
-            foreach (CommandBar commandBar in ctxMenus)
-            {
-
-                var menu = commandBar.FindControl(
-                    Type: MsoControlType.msoControlPopup,
-                    Tag: Category
-                    ) as CommandBarPopup;
-                if (menu == null)
-                {
-                    menu = commandBar.Controls.Add(MsoControlType.msoControlPopup, Temporary: true) as CommandBarPopup;
-                    menu.Caption = "BH." + Category;
-                    menu.Tag = Category;
-                }
-                Menus.Add(menu);
-            }
-
-            using (Engine.Excel.Profiling.Timer timer = new Engine.Excel.Profiling.Timer("AddToMenu"))
-            {
-                foreach (var menu in Menus) Caller.AddToMenu(menu.Controls);
-            }
-
-            Caller.ItemSelected += Caller_ItemSelected;
-        }
-
-        private void LoadFullMenu(CommandBarButton Ctrl, ref bool CancelDefault)
-        {
-            Ctrl.Delete();
-            CancelDefault = true;
         }
 
         /*******************************************/

--- a/Excel_UI/UI/Templates/CallerFormula.cs
+++ b/Excel_UI/UI/Templates/CallerFormula.cs
@@ -27,14 +27,17 @@ using Microsoft.Office.Core;
 using Microsoft.Office.Interop.Excel;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace BH.UI.Excel.Templates
 {
     public abstract class CallerFormula
     {
+
         /*******************************************/
         /**** Properties                        ****/
         /*******************************************/
@@ -118,13 +121,22 @@ namespace BH.UI.Excel.Templates
                 }
                 Menus.Add(menu);
             }
-
-
-            foreach (var menu in Menus) Caller.AddToMenu(menu.Controls);
-
             Caller.ItemSelected += Caller_ItemSelected;
         }
 
+        virtual public void AddToMenu()
+        {
+            if (!m_addedToMenu)
+            {
+                m_addedToMenu = true;
+
+                ThreadPool.QueueUserWorkItem((o) =>
+                {
+                    Caller.SetItem(null);
+                    foreach (var menu in Menus) Caller.AddToMenu(menu.Controls);
+                });
+            }
+        }
         /*******************************************/
         /**** Private Methods                   ****/
         /*******************************************/
@@ -165,5 +177,6 @@ namespace BH.UI.Excel.Templates
         /*******************************************/
 
         private FormulaDataAccessor m_dataAccessor;
+        private bool m_addedToMenu;
     }
 }

--- a/Excel_UI/UI/Templates/SelectorMenu_CommandBar.cs
+++ b/Excel_UI/UI/Templates/SelectorMenu_CommandBar.cs
@@ -75,21 +75,8 @@ namespace BH.UI.Excel.Templates
                 if (tree.Children.Count > 0)
                 {
                     CommandBarControls treeMenu = AppendMenuItem(menu, tree.Name);
-                    int size = TreeSize(tree);
-                    if (size > 200 && tree.Children.Count > 5) // Defer the population of large menu trees
-                    {
-                        AppendMenuItem(treeMenu, $"Load this menu ({size} items)", (CommandBarButton Ctrl, ref bool cancel) =>
-                        {
-                            cancel = true;
-                            foreach (Tree<T> childTree in tree.Children.Values.OrderBy(x => x.Name))
-                                AppendMenuTree(childTree, treeMenu);
-                            Ctrl.Visible = false;
-                        });
-                    } else
-                    {
-                        foreach (Tree<T> childTree in tree.Children.Values.OrderBy(x => x.Name))
-                            AppendMenuTree(childTree, treeMenu);
-                    }
+                    foreach (Tree<T> childTree in tree.Children.Values.OrderBy(x => x.Name))
+                        AppendMenuTree(childTree, treeMenu);
                 }
                 else
                 {
@@ -103,13 +90,6 @@ namespace BH.UI.Excel.Templates
             {
                 Compute.RecordError(e.Message);
             }
-        }
-
-        private int TreeSize(Tree<T> tree)
-        {
-            // Count the number of leaf nodes in a tree
-            if (tree.Children.Count == 0) return 1;
-            return tree.Children.Sum(t => TreeSize(t.Value));
         }
 
         /*******************************************/

--- a/Excel_UI/UI/Templates/SingleOptionCallerFormula.cs
+++ b/Excel_UI/UI/Templates/SingleOptionCallerFormula.cs
@@ -72,9 +72,6 @@ namespace BH.UI.Excel.Templates
             }
         }
 
-        public override void AddToMenu()
-        {
-        }
         /*******************************************/
         /**** Private Fields                    ****/
         /*******************************************/

--- a/Excel_UI/UI/Templates/SingleOptionCallerFormula.cs
+++ b/Excel_UI/UI/Templates/SingleOptionCallerFormula.cs
@@ -72,6 +72,9 @@ namespace BH.UI.Excel.Templates
             }
         }
 
+        public override void AddToMenu()
+        {
+        }
         /*******************************************/
         /**** Private Fields                    ****/
         /*******************************************/

--- a/Excel_UI/UI/Templates/SingleOptionCallerFormula.cs
+++ b/Excel_UI/UI/Templates/SingleOptionCallerFormula.cs
@@ -42,14 +42,6 @@ namespace BH.UI.Excel.Templates
 
         public SingleOptionCallerFormula(FormulaDataAccessor accessor, List<CommandBar> ctxMenus) : base(accessor, ctxMenus)
         {
-            foreach (var menu in Menus)
-            {
-                var btn = menu.Controls.Add(MsoControlType.msoControlButton, Temporary: true) as CommandBarButton;
-                btn.Tag = Guid.NewGuid().ToString();
-                btn.Caption = Caller.Name;
-                btn.Click += OnClick;
-                m_btns.Add(btn);
-            }
         }
 
         /*******************************************/

--- a/Excel_UI/UI/Templates/SingleOptionCallerFormula.cs
+++ b/Excel_UI/UI/Templates/SingleOptionCallerFormula.cs
@@ -40,35 +40,13 @@ namespace BH.UI.Excel.Templates
         /**** Constructors                      ****/
         /*******************************************/
 
-        public SingleOptionCallerFormula(FormulaDataAccessor accessor, List<CommandBar> ctxMenus) : base(accessor, ctxMenus)
+        public SingleOptionCallerFormula(FormulaDataAccessor accessor) : base(accessor)
         {
-        }
-
-        /*******************************************/
-        /**** Private Methods                   ****/
-        /*******************************************/
-
-        private void OnClick(CommandBarButton Ctrl, ref bool CancelDefault)
-        {
-            Range cell = Application.Selection as Range;
-            var cellcontents = "=" + Function;
-            if (Caller.InputParams.Count == 0)
-            {
-                cellcontents += "()";
-                if (cell != null) cell.Formula = cellcontents;
-            }
-            else
-            {
-                if (cell != null) cell.Formula = cellcontents;
-                Application.SendKeys("{F2}{(}", true);
-            }
         }
 
         /*******************************************/
         /**** Private Fields                    ****/
         /*******************************************/
-
-        private List<CommandBarButton> m_btns = new List<CommandBarButton>();
 
         public override string MenuRoot => "";
     }


### PR DESCRIPTION
 <!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #85 

~~It now defers adding items to the context menus until a workbook is opened and does so in background threads, I believe there is some locking going on in the COM interface still as it is a little sluggish whilst it does it but it does seem to complete faster than when it was done fully synchronously. Not entirely happy with it for this reason but struggling to find a better method. It was my hope that there would be some event to hook into as each sub-menu was opened so that we could build the menu on demand but it appears the MS Office API doesn't provide one.~~

Removes context menu entirely.

Closes #101 

As of #96 the leading part of the namespace for Create methods uses the namespace of the type it returns, in order to file methods where they are expected. an example being `Create.Structure.Elements.Bar` as opposed to `Create.Structure.Bar`, the create method for which resides in `BH.Engine.Structure.Create` and not `BH.Engine.Structure.Elements.Create`.

As such methods like `BH.Engine.Reflection.Create.Type(string)` (which returns `Type`) ends up as `Create.System.Type`, not `Create.Reflection.Type`.

This PR corrects this.

Closes #100 

Sometimes excel process continues after all windows are closed, caused by there being unreleased COM objects. Added a commit to make sure we release them correctly to avoid this.

### Test files
#85  [profiling.xlsx](https://github.com/BHoM/Excel_Toolkit/files/3271384/profiling.xlsx)

You will need to compare with `Excel_Toolkit-issue85-BaselinePerformanceWithProfiling` branch, which is just mater with the additional commit that adds the profiling stuff `cherry-pick`ed in.

#101 [namespaces.xlsx](https://github.com/BHoM/Excel_Toolkit/files/3277268/namespaces.xlsx)

This has methods from all the `BHoM_Engine` projects, if you calculate on `master` you should get `#NAME!` errors for some of them, this PR should resolve that.

#100 Hard to create a testfile for a transient failure upon close.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
