### PR TITLE
Fix warnings and errors on startup

### DIFF
--- a/Excel_UI/Addin/AddIn.cs
+++ b/Excel_UI/Addin/AddIn.cs
@@ -67,10 +67,6 @@ namespace BH.UI.Excel
                 ExcelDna.Registration.ExcelRegistration.RegisterCommands(ExcelDna.Registration.ExcelRegistration.GetExcelCommands());
                 AddInternalise();
 
-                //Hide error box showing methods not working properly
-                if (!DebugConfig.ShowExcelDNALog)
-                    ExcelDna.Logging.LogDisplay.Hide();
-
                 var app = ExcelDnaUtil.Application as Application;
                 app.WorkbookOpen += App_WorkbookOpen;
                 ExcelDna.IntelliSense.IntelliSenseServer.Install();

--- a/Excel_UI/UI/Components/oM/CreateType.cs
+++ b/Excel_UI/UI/Components/oM/CreateType.cs
@@ -46,7 +46,7 @@ namespace BH.UI.Excel.Components
 
                     string ns = t.Namespace;
                     if (ns.StartsWith("BH")) ns = ns.Split('.').Skip(2).Aggregate((a, b) => $"{a}.{b}");
-                    return "CreateType." + ns + "." + t.ToText();
+                    return "CreateType." + ns + "." + t.ToText(genericStart: "?",genericSeparator:"_",genericEnd:"");
                 }
                 return base.Name;
             }

--- a/Excel_UI/UI/Templates/FormulaDataAccessor.cs
+++ b/Excel_UI/UI/Templates/FormulaDataAccessor.cs
@@ -393,10 +393,11 @@ namespace BH.UI.Excel.Templates
             var argAttrs = rawParams
                         .Select(p =>
                         {
-                            string desc = p.Description + " " + p.DataType.ToText();
+                            string name = p.HasDefaultValue ? $"[{p.Name}]" : p.Name;
+                            string postfix = string.Empty;
                             if (p.HasDefaultValue)
                             {
-                                desc += " [default: " +
+                                postfix += " [default: " +
                                 (p.DefaultValue is string
                                     ? $"\"{p.DefaultValue}\""
                                     : p.DefaultValue == null
@@ -405,9 +406,11 @@ namespace BH.UI.Excel.Templates
                                 ) + "]";
                             }
 
+                            string desc = p.Description.Substring(0, 253 - postfix.Length - name.Length) + postfix;
+
                             return new ExcelArgumentAttribute()
                             {
-                                Name = p.HasDefaultValue ? $"[{p.Name}]" : p.Name,
+                                Name = name,
                                 Description = desc
                             };
                         }).ToList<object>();


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #114 
Closes #29 

- Fixes truncation warnings by truncating descriptions on our end. 
- Fixes type name duplication by removing it because it is redundant given Reflection engine's `Description()` method.
- Fixes Failure to register errors for Create Type methods for generic types by replacing `<>,` with legal characters.

I also no longer hide the error message box (which will only show if there are errors or warnings) so that there is an early warning system for a regression here.

### Test files
<!-- Link to test files to validate the proposed changes -->
n/a, just open Excel

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->