### PR TITLE
Fix incorrect truncation application

### DIFF
--- a/Excel_UI/UI/Components/oM/CreateCustom.cs
+++ b/Excel_UI/UI/Components/oM/CreateCustom.cs
@@ -47,7 +47,7 @@ namespace BH.UI.Excel.Components
                 {
                     string ns = t.Namespace;
                     if (ns.StartsWith("BH")) ns = ns.Split('.').Skip(2).Aggregate((a, b) => $"{a}.{b}");
-                    return "CreateCustom." + ns + "." + t.ToText();
+                    return "CreateCustom." + ns + "." + t.ToText(genericStart: "?",genericSeparator:"_",genericEnd:"");
                 }
                 return base.Name;
             }

--- a/Excel_UI/UI/Components/oM/CreateData.cs
+++ b/Excel_UI/UI/Components/oM/CreateData.cs
@@ -41,7 +41,8 @@ namespace BH.UI.Excel.Components
 
         public override string Name {
             get {
-                return "CreateData." + Caller.Name;
+                
+                return "CreateData." + valid.Replace(Caller.Name, "_");
             }
         }
         public override Caller Caller { get; } = new CreateDataCaller();
@@ -68,5 +69,6 @@ namespace BH.UI.Excel.Components
                 return names[i] + " " + output.Substring(brkt);
             }).ToList();
         }
+        private static System.Text.RegularExpressions.Regex valid = new System.Text.RegularExpressions.Regex("[^a-z0-9?_]", System.Text.RegularExpressions.RegexOptions.IgnoreCase);
     }
 }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #124 

Following #119 the substring command was being called on strings shorter than the length of the desired substring, as such was throwing an error and halting registration of the rest of the methods. Was also, as a result, hiding some other warnings and an error which have now also been resolved.

### Test files
https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/Excel_Toolkit/Excel_Toolkit-%23124-TruncationRegression?csf=1&e=viMu5K

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->