### PR TITLE
Only cache callers that have side effects/overheads

### DIFF
--- a/Excel_UI/Addin/AddIn.cs
+++ b/Excel_UI/Addin/AddIn.cs
@@ -45,7 +45,6 @@ namespace BH.UI.Excel
 {
     public class AddIn : IExcelAddIn
     {
-        private FormulaDataAccessor m_da;
         private Dictionary<string, CallerFormula> m_formulea;
         private List<CommandBar> m_menus;
         private List<CommandBarButton> m_internalise;
@@ -249,13 +248,11 @@ namespace BH.UI.Excel
             try
             {
                 Compute.LoadAllAssemblies(Environment.GetEnvironmentVariable("APPDATA") + @"\BHoM\Assemblies");
-                m_da = new FormulaDataAccessor();
 
-                Type fda = typeof(FormulaDataAccessor);
                 Type callform = typeof(CallerFormula);
 
-                Type[] constrtypes = new Type[] { fda };
-                object[] args = new object[] { m_da };
+                Type[] constrtypes = new Type[] { };
+                object[] args = new object[] { };
 
                 m_formulea = ExcelIntegration.GetExportedAssemblies()
                     .SelectMany(a => a.GetTypes())
@@ -264,7 +261,7 @@ namespace BH.UI.Excel
                     .Select(t => t.GetConstructor(constrtypes).Invoke(args) as CallerFormula)
                     .ToDictionary(o => o.Caller.GetType().Name);
 
-                var searcher = new FormulaSearchMenu(m_da, m_formulea);
+                var searcher = new FormulaSearchMenu(m_formulea);
                 searcher.SetParent(null);
 
                 searcher.ItemSelected += Formula_ItemSelected;

--- a/Excel_UI/Excel_UI.csproj
+++ b/Excel_UI/Excel_UI.csproj
@@ -122,6 +122,7 @@
     <Compile Include="UI\Components\oM\CreateObject.cs" />
     <Compile Include="UI\Components\oM\CreateType.cs" />
     <Compile Include="UI\Global\FormulaSearchMenu.cs" />
+    <Compile Include="UI\Templates\CachingDataAccessor.cs" />
     <Compile Include="UI\Templates\SingleOptionCallerFormula.cs" />
     <Compile Include="UI\Templates\IExcelSelectorMenu.cs" />
     <Compile Include="UI\Templates\SelectorMenuUtil.cs" />

--- a/Excel_UI/UI/Components/Adapter/CreateAdapter.cs
+++ b/Excel_UI/UI/Components/Adapter/CreateAdapter.cs
@@ -48,7 +48,6 @@ namespace BH.UI.Excel.Components
         /**** Constructors                      ****/
         /*******************************************/
 
-        public CreateAdapterFormula(FormulaDataAccessor accessor) : base(accessor) {
-        }
+        public CreateAdapterFormula() : base() { }
     }
 }

--- a/Excel_UI/UI/Components/Adapter/CreateRequest.cs
+++ b/Excel_UI/UI/Components/Adapter/CreateRequest.cs
@@ -46,7 +46,7 @@ namespace BH.UI.Excel.Components
         /**** Constructors                      ****/
         /*******************************************/
 
-        public CreateRequestFormula(FormulaDataAccessor accessor) : base(accessor) { }
+        public CreateRequestFormula() : base() { }
 
         /*******************************************/
     }

--- a/Excel_UI/UI/Components/Adapter/Delete.cs
+++ b/Excel_UI/UI/Components/Adapter/Delete.cs
@@ -44,7 +44,10 @@ namespace BH.UI.Excel.Components
         /**** Constructors                      ****/
         /*******************************************/
 
-        public DeleteFormula(FormulaDataAccessor accessor) : base(accessor) { }
+        public DeleteFormula() : base()
+        { 
+            Caller.SetDataAccessor(new CacheingDataAccessor());
+        }
 
         /*******************************************/
     }

--- a/Excel_UI/UI/Components/Adapter/Execute.cs
+++ b/Excel_UI/UI/Components/Adapter/Execute.cs
@@ -44,7 +44,10 @@ namespace BH.UI.Excel.Components
         /**** Constructors                      ****/
         /*******************************************/
 
-        public ExecuteFormula(FormulaDataAccessor accessor) : base(accessor) { }
+        public ExecuteFormula() : base()
+        {
+            Caller.SetDataAccessor(new CacheingDataAccessor());
+        }
 
         /*******************************************/
     }

--- a/Excel_UI/UI/Components/Adapter/Move.cs
+++ b/Excel_UI/UI/Components/Adapter/Move.cs
@@ -46,7 +46,10 @@ namespace BH.UI.Excel.Components
         /**** Constructors                      ****/
         /*******************************************/
 
-        public MoveFormula(FormulaDataAccessor accessor) : base(accessor) { }
+        public MoveFormula() : base()
+        {
+            Caller.SetDataAccessor(new CacheingDataAccessor());
+        }
 
         /*******************************************/
     }

--- a/Excel_UI/UI/Components/Adapter/Pull.cs
+++ b/Excel_UI/UI/Components/Adapter/Pull.cs
@@ -44,7 +44,10 @@ namespace BH.UI.Excel.Components
         /**** Constructors                      ****/
         /*******************************************/
 
-        public PullFormula(FormulaDataAccessor accessor) : base(accessor) { }
+        public PullFormula() : base() 
+        {
+            Caller.SetDataAccessor(new CacheingDataAccessor());
+        }
 
         /*******************************************/
     }

--- a/Excel_UI/UI/Components/Adapter/Push.cs
+++ b/Excel_UI/UI/Components/Adapter/Push.cs
@@ -42,7 +42,10 @@ namespace BH.UI.Excel.Components
         /**** Constructors                      ****/
         /*******************************************/
 
-        public PushFormula(FormulaDataAccessor accessor) : base(accessor) { }
+        public PushFormula() : base()
+        {
+            Caller.SetDataAccessor(new CacheingDataAccessor());
+        }
 
         /*******************************************/
     }

--- a/Excel_UI/UI/Components/Adapter/UpdateProperty.cs
+++ b/Excel_UI/UI/Components/Adapter/UpdateProperty.cs
@@ -44,7 +44,10 @@ namespace BH.UI.Excel.Components
         /**** Constructors                      ****/
         /*******************************************/
 
-        public UpdatePropertyFormula(FormulaDataAccessor accessor) : base(accessor) { }
+        public UpdatePropertyFormula() : base()
+        {
+            Caller.SetDataAccessor(new CacheingDataAccessor());
+        }
 
         /*******************************************/
     }

--- a/Excel_UI/UI/Components/Engine/Compute.cs
+++ b/Excel_UI/UI/Components/Engine/Compute.cs
@@ -44,7 +44,7 @@ namespace BH.UI.Excel.Components
         /**** Constructors                      ****/
         /*******************************************/
 
-        public ComputeFormula(FormulaDataAccessor accessor) : base(accessor) { }
+        public ComputeFormula() : base() { }
 
         /*******************************************/
     }

--- a/Excel_UI/UI/Components/Engine/Convert.cs
+++ b/Excel_UI/UI/Components/Engine/Convert.cs
@@ -44,7 +44,7 @@ namespace BH.UI.Excel.Components
         /**** Constructors                      ****/
         /*******************************************/
 
-        public ConvertFormula(FormulaDataAccessor accessor) : base(accessor) { }
+        public ConvertFormula() : base() { }
 
         /*******************************************/
     }

--- a/Excel_UI/UI/Components/Engine/Explode.cs
+++ b/Excel_UI/UI/Components/Engine/Explode.cs
@@ -47,7 +47,7 @@ namespace BH.UI.Excel.Components
         /**** Constructors                      ****/
         /*******************************************/
 
-        public ExplodeFormula(FormulaDataAccessor accessor) : base(accessor) { }
+        public ExplodeFormula() : base() { }
 
         /*******************************************/
     }

--- a/Excel_UI/UI/Components/Engine/FromJson.cs
+++ b/Excel_UI/UI/Components/Engine/FromJson.cs
@@ -42,7 +42,7 @@ namespace BH.UI.Excel.Components
         /**** Constructors                      ****/
         /*******************************************/
 
-        public FromJsonFormula(FormulaDataAccessor accessor) : base(accessor) { }
+        public FromJsonFormula() : base() { }
 
         /*******************************************/
     }

--- a/Excel_UI/UI/Components/Engine/GetInfo.cs
+++ b/Excel_UI/UI/Components/Engine/GetInfo.cs
@@ -42,7 +42,7 @@ namespace BH.UI.Excel.Components
         /**** Constructors                      ****/
         /*******************************************/
 
-        public GetInfoFormula(FormulaDataAccessor accessor) : base(accessor) { }
+        public GetInfoFormula() : base() { }
 
         /*******************************************/
     }

--- a/Excel_UI/UI/Components/Engine/GetProperty.cs
+++ b/Excel_UI/UI/Components/Engine/GetProperty.cs
@@ -42,7 +42,7 @@ namespace BH.UI.Excel.Components
         /**** Constructors                      ****/
         /*******************************************/
 
-        public GetPropertyFormula(FormulaDataAccessor accessor) : base(accessor) { }
+        public GetPropertyFormula() : base() { }
 
         /*******************************************/
     }

--- a/Excel_UI/UI/Components/Engine/Modify.cs
+++ b/Excel_UI/UI/Components/Engine/Modify.cs
@@ -44,7 +44,7 @@ namespace BH.UI.Excel.Components
         /**** Constructors                      ****/
         /*******************************************/
 
-        public ModifyFormula(FormulaDataAccessor accessor) : base(accessor) { }
+        public ModifyFormula() : base() { }
 
         /*******************************************/
     }

--- a/Excel_UI/UI/Components/Engine/Query.cs
+++ b/Excel_UI/UI/Components/Engine/Query.cs
@@ -44,7 +44,7 @@ namespace BH.UI.Excel.Components
         /**** Constructors                      ****/
         /*******************************************/
 
-        public QueryFormula(FormulaDataAccessor accessor) : base(accessor) { }
+        public QueryFormula() : base() { }
 
         /*******************************************/
     }

--- a/Excel_UI/UI/Components/Engine/SetProperty.cs
+++ b/Excel_UI/UI/Components/Engine/SetProperty.cs
@@ -42,7 +42,7 @@ namespace BH.UI.Excel.Components
         /**** Constructors                      ****/
         /*******************************************/
 
-        public SetPropertyFormula(FormulaDataAccessor accessor) : base(accessor) { }
+        public SetPropertyFormula() : base() { }
 
         /*******************************************/
     }

--- a/Excel_UI/UI/Components/Engine/ToJson.cs
+++ b/Excel_UI/UI/Components/Engine/ToJson.cs
@@ -42,7 +42,7 @@ namespace BH.UI.Excel.Components
         /**** Constructors                      ****/
         /*******************************************/
 
-        public ToJsonFormula(FormulaDataAccessor accessor) : base(accessor) { }
+        public ToJsonFormula() : base() { }
 
         /*******************************************/
     }

--- a/Excel_UI/UI/Components/oM/CreateCustom.cs
+++ b/Excel_UI/UI/Components/oM/CreateCustom.cs
@@ -63,7 +63,7 @@ namespace BH.UI.Excel.Components
         /**** Constructors                      ****/
         /*******************************************/
 
-        public CreateCustomFormula(FormulaDataAccessor accessor) : base(accessor) { }
+        public CreateCustomFormula() : base() { }
 
         /*******************************************/
     }

--- a/Excel_UI/UI/Components/oM/CreateData.cs
+++ b/Excel_UI/UI/Components/oM/CreateData.cs
@@ -55,7 +55,7 @@ namespace BH.UI.Excel.Components
         /**** Constructors                      ****/
         /*******************************************/
 
-        public CreateDataFormula(FormulaDataAccessor accessor) : base(accessor) { }
+        public CreateDataFormula() : base() { }
 
         protected override List<string> GetChoices()
         {

--- a/Excel_UI/UI/Components/oM/CreateDictionary.cs
+++ b/Excel_UI/UI/Components/oM/CreateDictionary.cs
@@ -42,7 +42,7 @@ namespace BH.UI.Excel.Components
         /**** Constructors                      ****/
         /*******************************************/
 
-        public CreateDictionaryFormula(FormulaDataAccessor accessor) : base(accessor) { }
+        public CreateDictionaryFormula() : base() { }
 
         /*******************************************/
     }

--- a/Excel_UI/UI/Components/oM/CreateEnum.cs
+++ b/Excel_UI/UI/Components/oM/CreateEnum.cs
@@ -60,7 +60,7 @@ namespace BH.UI.Excel.Components
         /**** Constructors                      ****/
         /*******************************************/
 
-        public CreateEnumFormula(FormulaDataAccessor accessor) : base(accessor) { }
+        public CreateEnumFormula() : base() { }
 
         protected override List<string> GetChoices()
         {

--- a/Excel_UI/UI/Components/oM/CreateObject.cs
+++ b/Excel_UI/UI/Components/oM/CreateObject.cs
@@ -67,6 +67,6 @@ namespace BH.UI.Excel.Components
         /**** Constructors                      ****/
         /*******************************************/
 
-        public CreateObjectFormula(FormulaDataAccessor accessor) : base(accessor) { }
+        public CreateObjectFormula() : base() { }
     }
 }

--- a/Excel_UI/UI/Components/oM/CreateType.cs
+++ b/Excel_UI/UI/Components/oM/CreateType.cs
@@ -60,7 +60,7 @@ namespace BH.UI.Excel.Components
         /**** Constructors                      ****/
         /*******************************************/
 
-        public CreateTypeFormula(FormulaDataAccessor accessor) : base(accessor) { }
+        public CreateTypeFormula() : base() { }
 
         /*******************************************/
     }

--- a/Excel_UI/UI/Global/FormulaSearchMenu.cs
+++ b/Excel_UI/UI/Global/FormulaSearchMenu.cs
@@ -43,9 +43,8 @@ namespace BH.UI.Excel.Global
         /**** Constructors                      ****/
         /*******************************************/
 
-        public FormulaSearchMenu(FormulaDataAccessor accessor, Dictionary<string, CallerFormula> callers) : base()
+        public FormulaSearchMenu(Dictionary<string, CallerFormula> callers) : base()
         {
-            m_accessor = accessor;
             m_callers = callers;
         }
 
@@ -118,7 +117,8 @@ namespace BH.UI.Excel.Global
             {
                 CallerFormula caller = m_callers[item.CallerType.Name];
                 caller.Caller.SetItem(item.Item);
-                return m_accessor.Wrap(caller, () => NotifySelection(item));
+                FormulaDataAccessor accessor = caller.Caller.DataAccessor as FormulaDataAccessor;
+                if(accessor != null) return accessor.Wrap(caller, () => NotifySelection(item));
             }
             return null;
         }
@@ -127,7 +127,6 @@ namespace BH.UI.Excel.Global
         /**** Private Fields                    ****/
         /*******************************************/
 
-        private FormulaDataAccessor m_accessor;
         private Dictionary<string, CallerFormula> m_callers;
     }
 }

--- a/Excel_UI/UI/Templates/CachingDataAccessor.cs
+++ b/Excel_UI/UI/Templates/CachingDataAccessor.cs
@@ -1,0 +1,133 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
+using BH.oM.UI;
+using BH.UI.Templates;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using ExcelDna.Integration;
+using System.Linq.Expressions;
+using System.Reflection;
+using BH.Engine.Reflection;
+using BH.Engine.Excel;
+
+namespace BH.UI.Excel.Templates
+{
+    public class CacheingDataAccessor : FormulaDataAccessor
+    {
+        /*******************************************/
+        /**** Constructors                      ****/
+        /*******************************************/
+
+        public CacheingDataAccessor()
+        {
+        }
+
+        /*******************************************/
+        /**** Public Methods                    ****/
+        /*******************************************/
+
+        public override bool SetDataItem<T>(int index, T data)
+        {
+            bool success = base.SetDataItem(index, data);
+            if(current_op != null)
+            {
+                output_cache[current_op] = base.GetOutput();
+                cache_age[current_op] = DateTime.Now;
+            }
+            return success;
+        }
+
+        public override bool Store(string function, params object[] in_)
+        {
+            if (function == null) function = "";
+            try
+            {
+                string reference = Engine.Excel.Query.Caller().RefText();
+                string key = $"{reference}:::{function}";
+
+                current_op = key;
+
+                if (cache_age.ContainsKey(current_op))
+                {
+                    var age = DateTime.Now.Subtract(cache_age[current_op]);
+                    if (age.TotalSeconds > 60)
+                    {
+                        cache_age.Remove(current_op);
+                        output_cache.Remove(current_op);
+                        input_cache.Remove(current_op);
+                    }
+                }
+
+                if (function.Length > 0 && input_cache.ContainsKey(key))
+                {
+                    var cached = input_cache[key];
+                    if (in_.Length == cached.Length)
+                    {
+                        bool same = true;
+                        for (int i = 0; i < in_.Length; i++)
+                        {
+                            if (!in_[i].Equals(cached[i]))
+                            {
+                                same = false;
+                                break;
+                            }
+                        }
+                        if (same) return false;
+                    }
+                }
+                input_cache[key] = in_;
+            } catch { }
+
+            return base.Store(function, in_);
+        }
+
+        /*******************************************/
+
+        public override object GetOutput()
+        {
+            if (current_op == null) return base.GetOutput();
+
+            object output = null;
+            output_cache.TryGetValue(current_op, out output);
+
+            base.SetDataItem(0, output);
+
+
+            return base.GetOutput();
+        }
+
+        /*******************************************/
+        /**** Private Fields                    ****/
+        /*******************************************/
+
+        private string current_op;
+        private Dictionary<string, object[]> input_cache = new Dictionary<string, object[]>();
+        private Dictionary<string, object> output_cache = new Dictionary<string, object>();
+        private Dictionary<string, DateTime> cache_age = new Dictionary<string, DateTime>();
+    }
+}

--- a/Excel_UI/UI/Templates/CallerFormula.cs
+++ b/Excel_UI/UI/Templates/CallerFormula.cs
@@ -91,10 +91,9 @@ namespace BH.UI.Excel.Templates
         /**** Constructors                      ****/
         /*******************************************/
 
-        public CallerFormula(FormulaDataAccessor accessor)
+        public CallerFormula()
         {
-            m_dataAccessor = accessor;
-            Caller.SetDataAccessor(m_dataAccessor);
+            Caller.SetDataAccessor(new FormulaDataAccessor());
         }
 
         /*******************************************/
@@ -135,11 +134,5 @@ namespace BH.UI.Excel.Templates
         {
             return Caller.Run();
         }
-
-        /*******************************************/
-        /**** Private Fields                    ****/
-        /*******************************************/
-
-        private FormulaDataAccessor m_dataAccessor;
     }
 }

--- a/Excel_UI/UI/Templates/CallerValueListFormula.cs
+++ b/Excel_UI/UI/Templates/CallerValueListFormula.cs
@@ -42,7 +42,7 @@ namespace BH.UI.Excel.Templates
             }
         }
 
-        public CallerValueListFormula(FormulaDataAccessor accessor) : base(accessor)
+        public CallerValueListFormula() : base()
         {
 
         }

--- a/Excel_UI/UI/Templates/SingleOptionCallerFormula.cs
+++ b/Excel_UI/UI/Templates/SingleOptionCallerFormula.cs
@@ -40,7 +40,7 @@ namespace BH.UI.Excel.Templates
         /**** Constructors                      ****/
         /*******************************************/
 
-        public SingleOptionCallerFormula(FormulaDataAccessor accessor) : base(accessor)
+        public SingleOptionCallerFormula() : base()
         {
         }
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #112 
Closes #121 

Reduces the caching of inputs and outputs to Adapter CRUD methods

This resolves issues with data accessor being used from other contexts, such as BHoM.Explode

The cache also times out which resolves some issues with keeping transient errors and not rerunning Modify methods correctly.

### Test files
https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/Excel_Toolkit/Excel_Toolkit-%23112-ExplodeFix?csf=1&e=Dcaixd

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Fixed `BHoM.Explode` not working
- Only debounce adapter methods


### Additional comments
<!-- As required -->