### PR TITLE
Excel toolkit #89,#132 set property,explode

### DIFF
--- a/Excel_Engine/Query/CleanList.cs
+++ b/Excel_Engine/Query/CleanList.cs
@@ -8,7 +8,7 @@ namespace BH.Engine.Excel
 {
     public static partial class Query
     {
-        public static List<T> CleanList<T>(List<T> list)
+        public static List<T> CleanList<T>(this List<T> list)
         {
             return list.FindAll(item => item != null);
         }

--- a/Excel_UI/Addin/AddIn.cs
+++ b/Excel_UI/Addin/AddIn.cs
@@ -61,7 +61,6 @@ namespace BH.UI.Excel
 
                 m_menus.Add((ExcelDnaUtil.Application as Application).CommandBars["Cell"]);
 
-                RegisterExcelMethods();
                 RegisterBHoMMethods();
                 ExcelDna.Registration.ExcelRegistration.RegisterCommands(ExcelDna.Registration.ExcelRegistration.GetExcelCommands());
                 AddInternalise();
@@ -211,38 +210,7 @@ namespace BH.UI.Excel
         /******* Private methods                            **************/
         /*****************************************************************/
 
-        private void RegisterExcelMethods()
-        {
-            //Get out all the methods marked with the excel attributes
-            IEnumerable<MethodInfo> allExcelMethods = ExcelIntegration.GetExportedAssemblies()
-                .SelectMany(x => x.GetTypes().SelectMany(y => y.GetMethods(BindingFlags.Public | BindingFlags.Static)))
-                .Where(x => x.GetCustomAttribute<ExcelFunctionAttribute>() != null);
 
-            List<MethodInfo> otherMethods = new List<MethodInfo>();
-
-            foreach (MethodInfo mi in allExcelMethods)
-            {
-                otherMethods.Add(mi);
-            }
-
-            List<object> fattrs = new List<object>();
-            List<List<object>> attrs = new List<List<object>>();
-            foreach (MethodInfo method in otherMethods)
-            {
-                var fa = method.GetCustomAttribute<ExcelFunctionAttribute>();
-                fa.Name = "BHoM." + (fa.Name != null ? fa.Name : method.Name);
-
-                fattrs.Add(fa);
-                attrs.Add(
-                    method.GetParameters()
-                        .Select(p => p.GetCustomAttribute<ExcelArgumentAttribute>() as object)
-                        .ToList()
-                );
-            }
-            ExcelIntegration.RegisterMethods(otherMethods,fattrs,attrs);
-        }
-
-        /*****************************************************************/
         private void RegisterBHoMMethods()
         {
             try

--- a/Excel_UI/Excel_UI.csproj
+++ b/Excel_UI/Excel_UI.csproj
@@ -95,6 +95,7 @@
     <Compile Include="Methods\Properties.cs" />
     <Compile Include="Project\Project.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="UI\Callers\Explode.cs" />
     <Compile Include="UI\Callers\CreateCustom.cs" />
     <Compile Include="UI\Components\Adapter\CreateAdapter.cs" />
     <Compile Include="UI\Components\Adapter\CreateRequest.cs" />

--- a/Excel_UI/Methods/Properties.cs
+++ b/Excel_UI/Methods/Properties.cs
@@ -30,6 +30,7 @@ using System.Reflection;
 using BH.oM.Base;
 using BH.Engine.Reflection;
 using System.Collections;
+using BH.Engine.Excel;
 using BH.UI.Global;
 
 namespace BH.UI.Excel
@@ -42,32 +43,14 @@ namespace BH.UI.Excel
 
         [ExcelFunction(Description = "Get all properties from an object. WARNING This is an array formula and will take up more than one cell!", Category = "BHoM")]
         public static object Explode(
-                [ExcelArgument(Name = "object ids")] object objectIds,
+                [ExcelArgument(Name = "object ids")] List<object> objects,
                 [ExcelArgument(Name = "Include the name of the properties")] bool includePropertyNames = false,
                 [ExcelArgument(Name = "Explode inner objects")] bool goDeep = false)
         {
-            Compute.ClearCurrentEvents();
+            Engine.Reflection.Compute.ClearCurrentEvents();
 
-            object[] _objectIds = new object[] { };
-            if (objectIds is object[,])
-            {
-                 _objectIds = (objectIds as object[,]).Cast<object>().ToArray().CleanArray();
-            } else if (objectIds is object[])
-            {
-                _objectIds = (objectIds as object[]);
-            } else if (objectIds is string)
-            {
-                _objectIds = new[] { objectIds };
-            }
-
-            //Clean the array
-            _objectIds = _objectIds.CleanArray();
-
-            //Get the object
-            List<object> objs = _objectIds.Select(x => {
-                var obj = Project.ActiveProject.GetAny(x.ToString());
-                return obj == null ? x : obj;
-            }).ToList();
+            // Clean the list
+            List<object> objs = objects.CleanList();
 
             if (objs == null)
                 return "Failed to get object";

--- a/Excel_UI/Project/Project.cs
+++ b/Excel_UI/Project/Project.cs
@@ -130,7 +130,7 @@ namespace BH.UI.Excel
 
         public string Add(IBHoMObject obj)
         {
-            string guid = ToString(obj.BHoM_Guid);
+            string guid = ToString(Guid.NewGuid());
             if (m_objects.ContainsKey(guid))
                 return guid;
 

--- a/Excel_UI/UI/Callers/Explode.cs
+++ b/Excel_UI/UI/Callers/Explode.cs
@@ -1,0 +1,20 @@
+﻿using BH.oM.Base;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BH.UI.Excel.Callers
+{
+    class ExplodeCaller : UI.Templates.MethodCaller
+    {
+        /*******************************************/
+        /**** Constructors                      ****/
+        /*******************************************/
+
+        public ExplodeCaller() : base(typeof(Properties).GetMethod("Explode"))
+        {
+        }
+    }
+}

--- a/Excel_UI/UI/Components/Engine/Explode.cs
+++ b/Excel_UI/UI/Components/Engine/Explode.cs
@@ -24,9 +24,9 @@ using System;
 using BH.oM.Base;
 using BH.UI.Excel.Templates;
 using BH.UI.Templates;
-using BH.UI.Components;
 using Microsoft.Office.Core;
 using System.Collections.Generic;
+using BH.UI.Excel.Callers;
 
 namespace BH.UI.Excel.Components
 {
@@ -37,7 +37,7 @@ namespace BH.UI.Excel.Components
         /*******************************************/
 
         // Bespoke Excel explode method
-        public override Caller Caller { get; } = new MethodCaller(typeof(Properties).GetMethod("Explode"));
+        public override Caller Caller { get; } = new ExplodeCaller();
 
         public override string Function { get; } = "BHoM.Explode";
             


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #89 

The internal object storage was using the object's `Guid` (when it's a `BHoM_Object`), however `SetProperty` first clones the object, making a new object with a different `Guid`, now a new ID is generated for each object stored.

Closes #132 

`ExplodeFormula` was not using a class named `ExplodeCaller` for its caller meaning it wasn't registered to be used from the selection event of the global search. That has now been resolved.

### Test files
<!-- Link to test files to validate the proposed changes -->
For #132 you should be able to just test from a blank excel that you can use `ctrl`+`shift`+`b` to create an explode call.

For #89 test file here: https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/Excel_Toolkit/Excel_Toolkit-issue89-SetProperty?csf=1&e=2Xoavl

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->

- Fixed SetProperty not working
- Fixed Explode not being able to be selected from `ctrl`+`shift`+`b`

### Additional comments
<!-- As required -->