### PR TITLE
Add Engine method to set cell content

### DIFF
--- a/Excel_Engine/Compute/Contents.cs
+++ b/Excel_Engine/Compute/Contents.cs
@@ -1,0 +1,28 @@
+﻿using ExcelDna.Integration;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BH.Engine.Excel
+{
+    public static partial class Compute
+    {
+        public static bool Contents(this oM.Excel.Reference reference, string value)
+        {
+            ExcelAsyncUtil.QueueAsMacro(() =>
+            {
+                try
+                {
+                    XlCall.Excel(XlCall.xlcFormula, value, reference.ToExcel());
+                }
+                catch (XlCallException exception)
+                {
+                    Reflection.Compute.RecordError(exception.Message);
+                }
+            });
+            return true;
+        }
+    }
+}

--- a/Excel_Engine/Excel_Engine.csproj
+++ b/Excel_Engine/Excel_Engine.csproj
@@ -54,6 +54,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Compute\Contents.cs" />
     <Compile Include="Compute\Note.cs" />
     <Compile Include="Timer.cs" />
     <Compile Include="Compute\NumberFormat.cs" />


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #134 

Adds a Compute method, Contents, that takes a reference and a string, to allow the caller to set the formula/value of a cell (sets the formula but that includes text/number constants)

### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/Excel_Toolkit/Excel_Toolkit-%23134-SetContents?csf=1&e=z1nWsd

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Add `Contents` compute engine method to set cell formula

### Additional comments
<!-- As required -->