### PR TITLE
Install Intellisense after registering methods

### DIFF
--- a/Excel_UI/Addin/AddIn.cs
+++ b/Excel_UI/Addin/AddIn.cs
@@ -56,7 +56,6 @@ namespace BH.UI.Excel
 
         public void AutoOpen()
         {
-            ExcelDna.IntelliSense.IntelliSenseServer.Install();
             m_application = Application.GetActiveInstance();
             using (Engine.Excel.Profiling.Timer timer = new Engine.Excel.Profiling.Timer("open"))
             {
@@ -71,6 +70,8 @@ namespace BH.UI.Excel
                 m_application.WorkbookOpenEvent += App_WorkbookOpen;
 
             }
+
+            ExcelDna.IntelliSense.IntelliSenseServer.Install();
         }
 
         private void AddInternalise()


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #141 

Registers the intellisense *after* registering methods, not before, else it doesn't pick them up.

### Test files
<!-- Link to test files to validate the proposed changes -->
Blank workbook or any other will exhibit the issue. Just type a BHoM excel method (or use ctrl+shift+b), and notice that no tooltip is presented on `master`, it should be presented in this PR.

master:
![image](https://user-images.githubusercontent.com/18450341/62935924-4c1f4900-bdc0-11e9-95d7-b7bb8cd68216.png)


this PR:
![image](https://user-images.githubusercontent.com/18450341/62935827-0b273480-bdc0-11e9-9e6b-5851ea293701.png)


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Fixed intellisense not appering for BHoM methods

### Additional comments
<!-- As required -->