### PR TITLE
Fix selecting from GlobalSearch not working

### DIFF
--- a/Excel_UI/Addin/AddIn.cs
+++ b/Excel_UI/Addin/AddIn.cs
@@ -235,6 +235,7 @@ namespace BH.UI.Excel
                 searcher.SetParent(null);
 
                 searcher.ItemSelected += Formula_ItemSelected;
+                globalSearch = new SearchMenu_WinForm();
                 globalSearch.ItemSelected += GlobalSearch_ItemSelected;
             }
             catch (Exception e)
@@ -288,7 +289,7 @@ namespace BH.UI.Excel
             var control = new System.Windows.Forms.ContainerControl();
             globalSearch.SetParent(control);
         }
-        private static SearchMenu globalSearch = new SearchMenu_WinForm();
+        private static SearchMenu globalSearch;
         
         public static void EnableBHoM(Action<bool> callback)
         {

--- a/Excel_UI/Addin/AddIn.cs
+++ b/Excel_UI/Addin/AddIn.cs
@@ -236,8 +236,6 @@ namespace BH.UI.Excel
 
                 searcher.ItemSelected += Formula_ItemSelected;
                 globalSearch.ItemSelected += GlobalSearch_ItemSelected;
-
-
             }
             catch (Exception e)
             {
@@ -286,11 +284,11 @@ namespace BH.UI.Excel
         [ExcelCommand(ShortCut = "^B")]
         public static void InitGlobalSearch()
         {
-            if(globalSearch == null) globalSearch = new SearchMenu_WinForm();
+
             var control = new System.Windows.Forms.ContainerControl();
             globalSearch.SetParent(control);
         }
-        private static SearchMenu globalSearch = null;
+        private static SearchMenu globalSearch = new SearchMenu_WinForm();
         
         public static void EnableBHoM(Action<bool> callback)
         {
@@ -325,7 +323,6 @@ namespace BH.UI.Excel
 
         private void GlobalSearch_ItemSelected(object sender, oM.UI.ComponentRequest e)
         {
-
             if (Formulea.ContainsKey(e.CallerType.Name))
             {
                 CallerFormula formula = Formulea[e.CallerType.Name];


### PR DESCRIPTION
  
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #144

<!-- Add short description of what has been fixed -->
Selecting an item from global search now inserts the function again, it had stopped doing so.

![globalsearch](https://user-images.githubusercontent.com/18450341/63110256-eb8c3980-bf82-11e9-8d53-c466287fd0b5.gif)


### Test files
<!-- Link to test files to validate the proposed changes -->
Works from blank excel so long as BHoM is enabled

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->