### PR TITLE
Remove call to UI_PostBuild.exe from post build event

### DIFF
--- a/Excel_UI/Excel_UI.csproj
+++ b/Excel_UI/Excel_UI.csproj
@@ -199,9 +199,10 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>"$(TargetDir)UI_PostBuild.exe" ..\..\ "$(APPDATA)\BHoM\Assemblies"
+    <PostBuildEvent>
 
 xcopy "$(TargetDir)*.xll"  "$(APPDATA)\BHoM\Assemblies" /C /Y
+
 xcopy "$(TargetDir)*.dna"  "$(APPDATA)\BHoM\Assemblies" /C /Y</PostBuildEvent>
   </PropertyGroup>
   <Import Project="..\packages\ExcelDna.AddIn.0.34.6\tools\ExcelDna.AddIn.targets" Condition="Exists('..\packages\ExcelDna.AddIn.0.34.6\tools\ExcelDna.AddIn.targets')" />


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #150 

Removes the call to the UI_PostBuild as this is handled by BHoM UI

### Test files
<!-- Link to test files to validate the proposed changes -->
n/a

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->