### PR TITLE
Add internalise button to all cell-related context menus

### DIFF
--- a/Excel_UI/Addin/AddIn.cs
+++ b/Excel_UI/Addin/AddIn.cs
@@ -66,7 +66,11 @@ namespace BH.UI.Excel
             using (Engine.Excel.Profiling.Timer timer = new Engine.Excel.Profiling.Timer("open"))
             {
                 m_menus = new List<CommandBar>();
-                m_menus.Add(m_application.CommandBars["Cell"]);
+                foreach (CommandBar commandBar in m_application.CommandBars)
+                {
+                    if (commandBar.Name == "Cell" || commandBar.Name.Contains("List Range"))
+                        m_menus.Add(commandBar);
+                }
 
                 m_application.WorkbookOpenEvent += App_WorkbookOpen;
             }

--- a/Excel_UI/Addin/AddIn.cs
+++ b/Excel_UI/Addin/AddIn.cs
@@ -79,14 +79,14 @@ namespace BH.UI.Excel
 
         private void AddInternalise()
         {
-            foreach (var cmb in m_menus)
+            m_btns = m_menus.Select((menu, i) =>
             {
-                var btn = cmb.Controls.Add(MsoControlType.msoControlButton,null,null,null, true) as CommandBarButton; 
-                btn.Tag = "Internalise_Data";
+                var btn = menu.Controls.Add(MsoControlType.msoControlButton, null, null, null, true) as CommandBarButton;
+                btn.Tag = "Internalise_Data" + i;
                 btn.Caption = "Internalise Data";
                 btn.ClickEvent += Internalise_Click;
-                btn.Dispose(false);
-            }
+                return btn;
+            }).ToList();
         }
 
         private void Internalise_Click(CommandBarButton Ctrl, ref bool CancelDefault)
@@ -313,6 +313,8 @@ namespace BH.UI.Excel
 
         
         private bool initialised = false;
+        private IEnumerable<CommandBarButton> m_btns;
+
         public static bool Enabled { get { return Instance.initialised; } }
 
         public static CallerFormula GetCaller(string caller)


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #149 

Adds the "Internalise Data" option to all views and contexts (tables and regular cells) 

### Test files
<!-- Link to test files to validate the proposed changes -->
Please follow https://github.com/BHoM/Excel_Toolkit/wiki/Testing-checklist and run through existing excel files to check for regressions.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Added "Internalise Data" button to all cell-related context menus

### Additional comments
<!-- As required -->