### PR TITLE
Shorten name of CreateObject for the constructable type case

### DIFF
--- a/Excel_UI/UI/Components/oM/CreateObject.cs
+++ b/Excel_UI/UI/Components/oM/CreateObject.cs
@@ -63,6 +63,15 @@ namespace BH.UI.Excel.Components
             }
         }
 
+        public override string Function
+        {
+            get
+            {
+                if (Caller.SelectedItem is Type) return $"{Name}?by_Properties";
+                return base.Function;
+            }
+        }
+
         /*******************************************/
         /**** Constructors                      ****/
         /*******************************************/


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #161 

Just changes the function name of Creator from Type-style create methods to `[name]?by_Properties()` to keep it shorter.

### Test files
Run through regular base tests but otherwise examine functions generated in a blank worksheet (using ribbon or `ctrl`+`shift`+`b` or just by typing in a formula)

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->