### PR TITLE
Pass ID to project storage of objects in DataSet creation

### DIFF
--- a/Excel_UI/Project/Project.cs
+++ b/Excel_UI/Project/Project.cs
@@ -116,33 +116,46 @@ namespace BH.UI.Excel
             return null;
         }
 
-
         /*****************************************/
         /****** "Interface" Add method     *******/
         /*****************************************/
         public string IAdd(object obj)
         {
-            return Add(obj as dynamic);
+            return IAdd(obj, ToString(Guid.NewGuid()));
+            
+        }
+
+        /*****************************************/
+
+        public string IAdd(object obj, Guid id)
+        {
+            return IAdd(obj, ToString(id));
+        }
+
+        /*****************************************/
+
+        public string IAdd(object obj, string id)
+        {
+            return Add(obj as dynamic, id);
         }
 
         /*****************************************/
         /***** Add methods             ***********/
         /*****************************************/
 
-        public string Add(IBHoMObject obj)
+        public string Add(IBHoMObject obj, string id) 
         {
-            string guid = ToString(Guid.NewGuid());
-            if (m_objects.ContainsKey(guid))
-                return guid;
+            if (m_objects.ContainsKey(id))
+                return id;
 
-            m_objects.Add(guid, obj);
+            m_objects.Add(id, obj);
 
             //Recurively add the objects dependecies
             foreach (object o in obj.PropertyObjects())
             {
                 if (o is IBHoMObject)
                 {
-                    Add(o as IBHoMObject);
+                    IAdd(o);
                 } 
             }
 
@@ -151,10 +164,10 @@ namespace BH.UI.Excel
             {
                 if (kvp.Value is IBHoMObject)
                 {
-                    Add(kvp.Value as IBHoMObject);
+                    IAdd(kvp.Value);
                 }
             }
-            return guid;
+            return id;
         }
 
         /*****************************************/
@@ -166,11 +179,10 @@ namespace BH.UI.Excel
 
         /*****************************************/
 
-        private string Add(object obj)
+        private string Add(object obj, string id)
         {
-            string guid = ToString(Guid.NewGuid());
-            m_objects[guid] = obj;
-            return guid;
+            m_objects[id] = obj;
+            return id;
         }
 
         /*****************************************/
@@ -254,16 +266,9 @@ namespace BH.UI.Excel
                     {
                         var kvp = (KeyValuePair<string, object>)obj;
                         m_objects.Add(kvp.Key, kvp.Value);
-                    } else if (obj is CustomObject)
-                    {
-                        var co = obj as CustomObject;
-                        foreach (var kvp in co.CustomData)
-                        {
-                            m_objects.Add(kvp.Key, kvp.Value);
-                        }
                     } else if (obj is IBHoMObject)
                     {
-                        Add(obj as IBHoMObject);
+                        IAdd(obj, (obj as IBHoMObject).BHoM_Guid);
                     }
                 }
                 catch (Exception e)

--- a/Excel_UI/UI/Components/oM/CreateData.cs
+++ b/Excel_UI/UI/Components/oM/CreateData.cs
@@ -21,6 +21,7 @@
  */
 
 using BH.Engine.Reflection;
+using BH.oM.Base;
 using BH.UI.Components;
 using BH.UI.Excel.Templates;
 using BH.UI.Templates;
@@ -62,7 +63,15 @@ namespace BH.UI.Excel.Components
             var names = MultiChoiceCaller.GetChoiceNames();
             return MultiChoiceCaller.Choices.Select((o, i) =>
             {
-                string id = Project.ActiveProject.IAdd(o);
+                string id;
+                if (o is IBHoMObject)
+                {
+                    id = Project.ActiveProject.IAdd(o, ((IBHoMObject)o).BHoM_Guid);
+                }
+                else
+                {
+                    id = Project.ActiveProject.IAdd(o);
+                }
                 return $"{names[i]} [{id}]";
             }).ToList();
         }


### PR DESCRIPTION
  
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #200 

<!-- Add short description of what has been fixed -->
For DataSets the ID field is required to be the same across runs due to being used as plain text from the validation it creates. This makes the IDs for the Datasets constant (based on BHoM_Guid) for datasets whilst keeping it random for transient objects.

### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:f:/s/BHoM/EqQ2avxQiBxDt5kWqFtlAasBjfepycURxycXDsR9E8qFVA?e=eOlGvQ

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->