### PR TITLE
Fix ValueList callers (drop down) i.e. CreateData and CreateEnum

### DIFF
--- a/Excel_UI/UI/Templates/CallerValueListFormula.cs
+++ b/Excel_UI/UI/Templates/CallerValueListFormula.cs
@@ -93,7 +93,7 @@ namespace BH.UI.Excel.Templates
                             {
                                 opt_array[0, i] = options[i];
                             }
-                            Caller.DataAccessor.SetDataItem(0, opt_array);
+                            Caller.DataAccessor.SetDataItem(0, ArrayResizer.Resize(opt_array));
                             ExcelAsyncUtil.QueueAsMacro(() =>
                             {
                                 try


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->


   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #203 

<!-- Add short description of what has been fixed -->
Fixes an issue with Value List caller types (i.e. CreateData and CreateEnum) where they error due to not populating the array formula correctly in the hidden sheet.

### Test files
<!-- Link to test files to validate the proposed changes -->
Can be tested from blank, create and data or enum component and it should populate the dropdown accordingly.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->