### PR TITLE
Truncate descriptions for ribbon tooltips if they exceed 1024 characters

### DIFF
--- a/Excel_UI/UI/Templates/SelectorMenu_RibbonXml.cs
+++ b/Excel_UI/UI/Templates/SelectorMenu_RibbonXml.cs
@@ -98,7 +98,12 @@ namespace BH.UI.Excel.Templates
                 element.SetAttribute("onAction", "FillFormula");
                 string description = method.IDescription();
                 if(description.Length > 0)
+                {
+                    // Ribbon XML schema has a hard limit of 1024 characters, truncate if we exceed it
+                    if (description.Length > 1024)
+                        description = description.Substring(0, 1024);
                     element.SetAttribute("supertip", description);
+                }
                 m_ItemLinks[id] = method;
             }
             element.SetAttribute("label", tree.Name);


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #214

<!-- Add short description of what has been fixed -->
Following https://github.com/BHoM/BHoM_Engine/pull/1586 the description of one enum type exceeds the hard limit in the MS Office XML Schema for Ribbon UIs, this affects the Create Enum and Create Type menus, causing them not to display at all. This PR truncates the description if this limit is exceded.
Before:  
![image](https://user-images.githubusercontent.com/18450341/77646408-61ff0a00-6f5c-11ea-8d8b-219eff504b2a.png)

After:  
![image](https://user-images.githubusercontent.com/18450341/77646489-8bb83100-6f5c-11ea-81a2-a1c052069e25.png)


### Test files
<!-- Link to test files to validate the proposed changes -->
Bug reproduces on any file/blank sheet

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->