### PR TITLE
Fix inconsistency in Get/Set property formulae

### DIFF
--- a/Excel_UI/UI/Components/Engine/GetProperty.cs
+++ b/Excel_UI/UI/Components/Engine/GetProperty.cs
@@ -38,6 +38,8 @@ namespace BH.UI.Excel.Components
 
         public override Caller Caller { get; } = new GetPropertyCaller();
 
+        public override string Function { get; } = "Engine.GetProperty";
+
         /*******************************************/
         /**** Constructors                      ****/
         /*******************************************/

--- a/Excel_UI/UI/Components/Engine/SetProperty.cs
+++ b/Excel_UI/UI/Components/Engine/SetProperty.cs
@@ -38,6 +38,8 @@ namespace BH.UI.Excel.Components
 
         public override Caller Caller { get; } = new SetPropertyCaller();
 
+        public override string Function { get; } = "Engine.SetProperty";
+
         /*******************************************/
         /**** Constructors                      ****/
         /*******************************************/


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #230 

<!-- Add short description of what has been fixed -->
Fixed inconsistent naming between the set and get property methods of the engine. Used simple solution of just overriding the Function property for these Callers as there is a plan to make a larger change to generate them differently anyway that will remove this.

### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->