### PR TITLE
Deregister workbook saved event from workbook object when workbook closed

### DIFF
--- a/Excel_UI/Addin/AddIn.cs
+++ b/Excel_UI/Addin/AddIn.cs
@@ -86,8 +86,11 @@ namespace BH.UI.Excel
 
         public void AutoClose()
         {
+            // note: This method only runs if the Addin gets disabled during
+            // execution, it does not run when excel closes.
             ExcelDna.IntelliSense.IntelliSenseServer.Uninstall();
             m_Application.WorkbookOpenEvent -= App_WorkbookOpen;
+            m_Application.WorkbookBeforeCloseEvent -= App_WorkbookClosed;
         }
 
         /*******************************************/
@@ -365,7 +368,7 @@ namespace BH.UI.Excel
 
         /*******************************************/
 
-        private void App_WorkbookClosed(Workbook workbook, ref bool Cancel)
+        private void App_WorkbookClosed(Workbook workbook, ref bool cancel)
         {
             ComponentManager.RemoveManager(workbook);
         }

--- a/Excel_UI/Addin/AddIn.cs
+++ b/Excel_UI/Addin/AddIn.cs
@@ -76,8 +76,8 @@ namespace BH.UI.Excel
                     m_Menus.Add(commandBar);
             }
 
-            m_Application.NewWorkbookEvent += App_WorkbookNew;
             m_Application.WorkbookOpenEvent += App_WorkbookOpen;
+            m_Application.WorkbookBeforeCloseEvent += App_WorkbookClosed;
 
             ExcelAsyncUtil.QueueAsMacro(() => InitBHoMAddin());
         }
@@ -87,7 +87,6 @@ namespace BH.UI.Excel
         public void AutoClose()
         {
             ExcelDna.IntelliSense.IntelliSenseServer.Uninstall();
-            m_Application.NewWorkbookEvent -= App_WorkbookNew;
             m_Application.WorkbookOpenEvent -= App_WorkbookOpen;
         }
 
@@ -232,13 +231,6 @@ namespace BH.UI.Excel
 
         /*******************************************/
 
-        private void App_WorkbookNew(Workbook workbook)
-        {
-            InitBHoMAddin();
-            var manager = ComponentManager.GetManager(workbook);
-        }
-
-        /*******************************************/
 
         private void ComponentManager_ComponentRestored(object sender, KeyValuePair<string, Tuple<string, string>> restored)
         {
@@ -369,6 +361,13 @@ namespace BH.UI.Excel
 
                 }
                 Project.ActiveProject.Deserialize(json);
+        }
+
+        /*******************************************/
+
+        private void App_WorkbookClosed(Workbook workbook, ref bool Cancel)
+        {
+            ComponentManager.RemoveManager(workbook);
         }
 
         /*******************************************/

--- a/Excel_UI/UI/Global/ComponentManager.cs
+++ b/Excel_UI/UI/Global/ComponentManager.cs
@@ -11,7 +11,7 @@ using ExcelDna.Integration;
 
 namespace BH.UI.Excel.Global
 {
-    class ComponentManager
+    class ComponentManager : IDisposable
     {
         /*************************************/
         /**** Methods                     ****/
@@ -30,7 +30,23 @@ namespace BH.UI.Excel.Global
 
         public static ComponentManager GetManager(string name)
         {
-            return m_Managers.ContainsKey(name) ? m_Managers[name] : null;
+            if (!m_Managers.ContainsKey(name))
+            {
+                var workbook = Application.GetActiveInstance().Workbooks[name];
+                m_Managers.Add(workbook.Name, new ComponentManager(workbook));
+            }
+            return m_Managers[name];
+        }
+
+        /*************************************/
+        public static bool RemoveManager(Workbook workbook)
+        {
+            if (m_Managers.ContainsKey(workbook.Name))
+            {
+                m_Managers[workbook.Name].Dispose();
+                return true;
+            }
+            return false;
         }
 
         /*************************************/
@@ -112,6 +128,14 @@ namespace BH.UI.Excel.Global
                 used.Clear();
             }
             catch { }
+        }
+
+        /*************************************/
+
+        public void Dispose()
+        {
+            m_Workbook.AfterSaveEvent -= OnWorkbookSaved;
+            m_Managers.Remove(m_Name);
         }
 
         /*************************************/


### PR DESCRIPTION


<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #171 

<!-- Add short description of what has been fixed -->
Seems to be the cause of excel crashing and reopening on exit. From what i can tell it looks like something comes along deregistering event handlers in the exit procedure of Excel. One of the event handlers introduced by #208 was directly on the Workbook object which then doesn't exist (or sometimes/often doesn't exist, thanks to garbage collection being non-deterministic) by the time the event handler is cleared up, leading to a "Object reference not set to an instance of an object." exception that goes unhandled. I have also moved the creation of said event handler to the first moment BHoM is used for that workbook.

### Test files
<!-- Link to test files to validate the proposed changes -->
Open a new workbook, use any BHoM method from Ctrl+Shift+B or Ribbon, close the workbook.

Also if people testing can try to confirm the crash *does* happen by commenting line 46 of `ComponentManager.cs` and doesn't when this line is present using the same procedure as above.

```cs
                m_Managers[workbook.Name].Dispose();
```

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Fix Excel Crashing on exit bug (#171)

### Additional comments
<!-- As required -->