### PR TITLE
Reinstating initialise BHoM through ribbon

### DIFF
--- a/Excel_UI/Addin/AddIn.cs
+++ b/Excel_UI/Addin/AddIn.cs
@@ -69,12 +69,6 @@ namespace BH.UI.Excel
             m_Application = Application.GetActiveInstance();
 
             ComponentManager.ComponentRestored += ComponentManager_ComponentRestored;
-            m_Menus = new List<CommandBar>();
-            foreach (CommandBar commandBar in m_Application.CommandBars)
-            {
-                if (commandBar.Name == "Cell" || commandBar.Name.Contains("List Range"))
-                    m_Menus.Add(commandBar);
-            }
 
             m_Application.WorkbookOpenEvent += App_WorkbookOpen;
             m_Application.WorkbookBeforeCloseEvent += App_WorkbookClosed;
@@ -91,20 +85,6 @@ namespace BH.UI.Excel
             ExcelDna.IntelliSense.IntelliSenseServer.Uninstall();
             m_Application.WorkbookOpenEvent -= App_WorkbookOpen;
             m_Application.WorkbookBeforeCloseEvent -= App_WorkbookClosed;
-        }
-
-        /*******************************************/
-
-        private void AddInternalise()
-        {
-            m_Btns = m_Menus.Select((menu, i) =>
-            {
-                var btn = menu.Controls.Add(MsoControlType.msoControlButton, null, null, null, true) as CommandBarButton;
-                btn.Tag = "Internalise_Data" + i;
-                btn.Caption = "Internalise Data";
-                btn.ClickEvent += Internalise_Click;
-                return btn;
-            }).ToList();
         }
 
         /*******************************************/
@@ -126,7 +106,6 @@ namespace BH.UI.Excel
                 }
             }
             ExcelDna.Registration.ExcelRegistration.RegisterCommands(ExcelDna.Registration.ExcelRegistration.GetExcelCommands());
-            AddInternalise();
             ExcelDna.IntelliSense.IntelliSenseServer.Refresh();
             m_Initialised = true;
             ExcelDna.Logging.LogDisplay.Clear();
@@ -454,7 +433,6 @@ namespace BH.UI.Excel
         /*******************************************/
 
         private Dictionary<string, CallerFormula> m_Formulea;
-        private List<CommandBar> m_Menus;
         private Application m_Application;
         private static SearchMenu m_GlobalSearch = null;
         private bool m_Initialised = false;

--- a/Excel_UI/Addin/AddIn.cs
+++ b/Excel_UI/Addin/AddIn.cs
@@ -68,12 +68,7 @@ namespace BH.UI.Excel
 
             m_Application = Application.GetActiveInstance();
 
-            ComponentManager.ComponentRestored += ComponentManager_ComponentRestored;
-
             m_Application.WorkbookOpenEvent += App_WorkbookOpen;
-            m_Application.WorkbookBeforeCloseEvent += App_WorkbookClosed;
-
-            ExcelAsyncUtil.QueueAsMacro(() => InitBHoMAddin());
         }
 
         /*******************************************/
@@ -105,6 +100,9 @@ namespace BH.UI.Excel
                     Engine.Reflection.Compute.RecordError(e.Message);
                 }
             }
+            ComponentManager.ComponentRestored += ComponentManager_ComponentRestored;
+            m_Application.WorkbookBeforeCloseEvent += App_WorkbookClosed;
+
             ExcelDna.Registration.ExcelRegistration.RegisterCommands(ExcelDna.Registration.ExcelRegistration.GetExcelCommands());
             ExcelDna.IntelliSense.IntelliSenseServer.Refresh();
             m_Initialised = true;


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Related to #233 but does not fully close.

This PR is reinstating the functionality to initialise the Excel BHoM Plugin via the button on the ribbon.
The purpose of this is to isolate the bug in in issue #233 to only occur when the user proactively chooses to use BHoM through the ribbon or opens an already BHoM enabled workbook.




### Test files
<!-- Link to test files to validate the proposed changes -->
Try opening Excel using this PR. 
1. Try using Excel _without_ activating BHoM on the ribbon or using BHoM functionality. Close Excel after a period. You should not experience the issue in #233 
2. Try using Excel _with_ BHoM functionality. Close Excel after a period. You might well experience the issue in #233 - good to record if you are.


