### PR TITLE
Fix bugs related to drop down components

### DIFF
--- a/Excel_UI/Addin/AddIn_Formulas.cs
+++ b/Excel_UI/Addin/AddIn_Formulas.cs
@@ -32,6 +32,7 @@ using Microsoft.Office.Interop.Excel;
 using BH.oM.UI;
 using BH.UI.Base;
 using BH.UI.Excel.Templates;
+using BH.oM.Base;
 
 namespace BH.UI.Excel
 {
@@ -109,7 +110,18 @@ namespace BH.UI.Excel
                 if (formula != null)
                 {
                     formula.Caller.Read(callerJson);
-                    Register(formula);
+                    Register(formula); 
+                }
+
+                // Register the choices as objects if formula is a dropdown
+                CallerValueListFormula valueList = formula as CallerValueListFormula;
+                if (valueList != null)
+                {
+                    foreach (object choice in valueList.MultiChoiceCaller.Choices)
+                    {
+                        if (choice is IObject)
+                            IAddObject(choice);
+                    }
                 }
             }
         }

--- a/Excel_UI/Caller/CallerFormula_Run.cs
+++ b/Excel_UI/Caller/CallerFormula_Run.cs
@@ -56,7 +56,7 @@ namespace BH.UI.Excel.Templates
 
             // Log usage
             Application app = ExcelDnaUtil.Application as Application;
-            Engine.UI.Compute.LogUsage("Excel", app?.Version, InstanceId, Caller.Name, Caller.SelectedItem, errors.ToList());
+            Engine.UI.Compute.LogUsage("Excel", app?.Version, InstanceId, Caller.GetType().Name, Caller.SelectedItem, errors.ToList());
 
             // Return result
             return result;

--- a/Excel_UI/Templates/CallerValueListFormula.cs
+++ b/Excel_UI/Templates/CallerValueListFormula.cs
@@ -92,6 +92,9 @@ namespace BH.UI.Excel.Templates
                             validation.Add(XlDVType.xlValidateList, XlDVAlertStyle.xlValidAlertWarning, XlFormatConditionOperator.xlBetween, string.Join(",", options), Type.Missing);
                             validation.InCellDropdown = true;
                             validation.IgnoreBlank = true;
+
+                            // Log usage
+                            Engine.UI.Compute.LogUsage("Excel", app?.Version, InstanceId, Caller.GetType().Name, Caller.SelectedItem);
                         });
 
                         m_DataAccessor.SetDataItem(0, "");


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #245 
Closes #246

Fixes the problems highlighted in #245 and listed in the changelog below. 
There is still a significant problem though: files containing a drop down component will throw an error message when reopen, requiring the file to be repaired (no data lost). The corresponding cells will have lost their dropdown but will otherwise work fine.

This PR is an improvement on the master even in this state so happy to merge and solve the last problem separately if I cannot figure it out today (it is more complex than I thought).

### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
- Now logging usage of drop down components
- Fixing choices from dropdown component not in memory after reopening the file
- Usage log now saving caller type name instead of caller name

### Additional comments
<!-- As required -->