### PR TITLE
Fix multi-output formulas

### DIFF
--- a/Excel_UI/Caller/CallerFormula_Run.cs
+++ b/Excel_UI/Caller/CallerFormula_Run.cs
@@ -63,6 +63,23 @@ namespace BH.UI.Excel.Templates
         }
 
         /*******************************************/
+
+        public virtual object RunWithOutputConfig(object[] inputs, bool includeOutputNames = false, bool transposeOutputs = false)
+        {
+            if (m_DataAccessor != null)
+            {
+                m_DataAccessor.TransposeOutputs = transposeOutputs;
+
+                if (includeOutputNames)
+                    m_DataAccessor.OutputNames = Caller.OutputParams.Select(x => x.Name).ToList();
+                else
+                    m_DataAccessor.OutputNames = new List<string>();
+            }
+
+            return Run(inputs);
+        }
+
+        /*******************************************/
     }
 }
 

--- a/Excel_UI/Templates/FormulaDataAccessor.cs
+++ b/Excel_UI/Templates/FormulaDataAccessor.cs
@@ -38,6 +38,10 @@ namespace BH.UI.Excel.Templates
 
         public List<object> Outputs { get; private set; } = new List<object> { ExcelError.ExcelErrorNull };
 
+        public List<string> OutputNames { get; set; } = new List<string>();
+
+        public bool TransposeOutputs { get; set; } = false;
+
 
         /*******************************************/
         /**** Public Methods                    ****/
@@ -62,7 +66,20 @@ namespace BH.UI.Excel.Templates
             if (Outputs.Count == 1)
                 return AddIn.ToExcel(Outputs[0]);
             else
-                return AddIn.ToExcel(Outputs.ToList());
+            {
+                List<List<object>> result = new List<List<object>> { Outputs };
+                if (OutputNames.Count == Outputs.Count)
+                    result.Insert(0, OutputNames.ToList<object>());
+
+                if (TransposeOutputs)
+                {
+                    result = result.SelectMany(row => row.Select((value, index) => new { value, index }))
+                        .GroupBy(cell => cell.index, cell => cell.value)
+                        .Select(g => g.ToList()).ToList();
+                }
+
+                return AddIn.ToExcel(result);
+            }    
         }
 
 


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #224 

A few things have changed in the way multi-output formulas/components are being handled:
- Instead of just providing the first output (or null as it was in the past), it creates a table with all the outputs (same as Explode).
- two extra arguments are added to the end of each formula
   - `_includeOutputNames`: this means the first row/column of the table will provide the output names making it easier to identify them (similar to Explode).
   - `"_transposeOutputs`: transpose the output table 


### Test files
Just use any multi-output formula and check that you are happy with the way it works. As always, also test that it still working fine after saving and reopening the file.

