### PR TITLE
Fix Explode failing when going deep finds nulls

### DIFF
--- a/Excel_Engine/Query/Explode.cs
+++ b/Excel_Engine/Query/Explode.cs
@@ -24,11 +24,13 @@ namespace BH.Engine.Excel
         public static object Explode(List<object> objects, bool includePropertyNames = false, bool goDeep = false, bool transpose = false)
         {
             Engine.Reflection.Compute.ClearCurrentEvents();
+            if (objects == null || objects.Count == 0)
+                return "No objects to explode";
 
             // Clean the list
             List<object> objs = objects.FindAll(item => item != null);
-            if (objs == null)
-                return "Failed to get object";
+            if (objs == null || objs.Count == 0)
+                return "Failed to get non null objects";
 
             // Get the property dictionary for the object
             List<Dictionary<string, object>> props = GetPropertyDictionaries(objs, goDeep);
@@ -85,9 +87,12 @@ namespace BH.Engine.Excel
         /*******************************************/
 
         private static void GetPropertyDictionary(ref Dictionary<string, object> dict, object obj, bool goDeep = false, string parentType = "")
-
         {
-            if (obj.GetType().IsPrimitive || obj is string || obj is Guid || obj is Enum)
+            if (obj == null)
+            {
+                return;
+            }
+            else if (obj.GetType().IsPrimitive || obj is string || obj is Guid || obj is Enum)
             {
                 string key = parentType.Length > 0 ? parentType : "Value";
                 dict[key] = obj;


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #253 
Closes #254 

There were quite a few missing null checks on the Explode methods. This was causing the whole Explode (going deep) to fail as soon as a null was found on a sub-object. 

@BingWangUS , I think this fixes your problem as well. It appears that the `ExcelNameError` that i mentioned earlier is due to the order in which Excel process the cells and some asynchronous joy that I won't mention here. Eventually Excel figures it out but the early crash of Explode du to receiving a null instead of a list was preventing Excel to run the final and relevant Explode. Not sure it that makes sense at all but, if ou rerun the Explode on your `AverageData` spreadsheet, things should now work fine. Let me know if they don't.

@kayleighhoude , the exploe should now work on the spreadsheet you sent me via email. At least it is on the internalised data (as I don't have the Revit file you are pulling that data from).

@IsakNaslundBh , adding you here as you are the only core developer that is also regularly using Excel. Adding a test file below if you want to have a look. Otherwise I mainly expect you to review the code side. Should be pretty straightforward as I simply added a few null checks. 

### Test files
https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/Excel_Toolkit/Excel_Toolkit-%23253-FixExplodeOfNullBug?csf=1&web=1&e=ZObrLa

The Explode is in cell D6


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->