### PR TITLE
Fix additional parameters in formula name for method with IOutput output

### DIFF
--- a/Excel_UI/Addin/AddIn_Formulas.cs
+++ b/Excel_UI/Addin/AddIn_Formulas.cs
@@ -135,7 +135,7 @@ namespace BH.UI.Excel
         private static Tuple<Delegate, ExcelFunctionAttribute, List<object>> GetExcelDelegate(CallerFormula caller)
         {
             int nbInputs = caller.Caller.InputParams.Count;
-            List<ParamInfo> inputs = caller.Caller.InputParams;
+            List<ParamInfo> inputs = caller.Caller.InputParams.ToList();
             ParameterExpression[] lambdaParams = inputs.Select(p => Expression.Parameter(typeof(object))).ToArray();
             NewArrayExpression array = Expression.NewArrayInit(typeof(object), lambdaParams);
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #256

See issue

### Test files
Simply create a push formula an make sure the formula name is `Adapter.Push?by_BHoMAdapter_IEnumerableOfObject_String_PushType_ActionConfig_Boolean`


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->