### PR TITLE
Change type representation in cell to a more explicit description

### DIFF
--- a/Excel_UI/Addin/AddIn_Converts.cs
+++ b/Excel_UI/Addin/AddIn_Converts.cs
@@ -104,7 +104,13 @@ namespace BH.UI.Excel
                         return date.Value.ToOADate();
                 }
 
-                return data.GetType().ToText() + " [" + AddIn.IAddObject(data) + "]";
+                string name = "";
+                if (data is Type)
+                    name = ((Type)data).ToText(true);
+                else
+                    name = data.GetType().ToText();
+
+                return name + " [" + AddIn.IAddObject(data) + "]";
             }
             catch
             {


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #258 

Change the representation of a `Type` in a cell to 

![image](https://user-images.githubusercontent.com/16853390/94116596-d66c2480-fe7d-11ea-9d32-8b9679340dc4.png)

instead of 

![image](https://user-images.githubusercontent.com/16853390/94116173-462ddf80-fe7d-11ea-83a5-d3d406294097.png)

This is a small thing so not sure whether it should be merged on this side of the beta. This is very risk free though so happy to let democracy decide. Also good to have your feedback on what you think about this change. I have decided to go for the full namespace representation of the type to avoid confusion and also better distinguish it from object representation (GH was kind of giving us both without effort).

