### PR TITLE
Fix numlock turning off when creating BHoM formula

### DIFF
--- a/Excel_UI/Addin/AddIn_Workbook.cs
+++ b/Excel_UI/Addin/AddIn_Workbook.cs
@@ -135,8 +135,9 @@ namespace BH.UI.Excel
                         Application app = ExcelDnaUtil.Application as Application;
                         if (app != null)
                         {
+                            bool numLocked = System.Windows.Forms.Control.IsKeyLocked(System.Windows.Forms.Keys.NumLock);
                             app.SendKeys("{F2}{(}", true);
-                            if (System.Windows.Forms.Control.IsKeyLocked(System.Windows.Forms.Keys.NumLock))
+                            if (numLocked)
                                 app.SendKeys("{NUMLOCK}", true);
                         }
                     }


### PR DESCRIPTION

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #265


### Test files
Just make sure that NumLock doesn't turn off anymore when creating a BHoM formula from the global menu.
