### PR TITLE
Set .NET framework version to 4.5.2

### DIFF
--- a/Excel_UI/Excel_UI.csproj
+++ b/Excel_UI/Excel_UI.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>BH.UI.Excel</RootNamespace>
     <AssemblyName>Excel_UI</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>


### PR DESCRIPTION
### Issues addressed by this PR
Set the .NET framework version of the projects in this toolkit to 4.5.2

### Test files
This PR will be reviewed by making sure that an installer can be produced from it. 