### PR TITLE
Add ability to force property types on CreateCustom

### DIFF
--- a/Excel_UI/Caller/CallerFormula_MethodCall.cs
+++ b/Excel_UI/Caller/CallerFormula_MethodCall.cs
@@ -1,0 +1,161 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *
+ *
+ * The BHoM is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3.0 of the License, or
+ * (at your option) any later version.
+ *
+ * The BHoM is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
+ */
+
+using BH.UI.Base;
+using ExcelDna.Integration;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Collections;
+using BH.oM.UI;
+using System.Reflection;
+
+namespace BH.UI.Excel.Templates
+{
+    public abstract partial class CallerFormula
+    {
+        /*******************************************/
+        /**** Methods                           ****/
+        /*******************************************/
+
+        public virtual Tuple<Delegate, ExcelFunctionAttribute, List<object>> GetExcelDelegate()
+        {
+            List<ParamInfo> inputs = Caller.InputParams.ToList();
+            ParameterExpression[] lambdaParams = inputs.Select(p => Expression.Parameter(typeof(object))).ToArray();
+            
+            // Define the method to call depending on the number of outputs
+            MethodCallExpression methodCall = GetMethodCall(ref inputs, ref lambdaParams);
+
+            LambdaExpression lambda = Expression.Lambda(methodCall, lambdaParams);
+            return new Tuple<Delegate, ExcelFunctionAttribute, List<object>>(
+                lambda.Compile(),
+                GetFunctionAttribute(),
+                GetArgumentAttributes(inputs).ToList<object>()
+            );
+        }
+
+
+        /*******************************************/
+        /**** Private Methods                   ****/
+        /*******************************************/
+
+        protected virtual MethodCallExpression GetMethodCall(ref List<ParamInfo> inputs, ref ParameterExpression[] lambdaParams)
+        {
+            int nbInputs = Caller.InputParams.Count;
+            NewArrayExpression array = Expression.NewArrayInit(typeof(object), lambdaParams);
+
+            MethodCallExpression methodCall;
+            if (Caller.OutputParams.Count > 1)
+            {
+                List<ParamInfo> extraInputs = new List<ParamInfo>
+                {
+                    new ParamInfo { DataType = typeof(bool), DefaultValue = false, HasDefaultValue = true, IsRequired = false, Name = "_includeOutputNames", Description = "Include the name of the outputs" },
+                    new ParamInfo { DataType = typeof(bool), DefaultValue = false, HasDefaultValue = true, IsRequired = false, Name = "_transposeOutputs", Description = "Transpose the resulting table (i.e. one output per row instead of per column)" }
+                };
+
+                inputs.AddRange(extraInputs);
+                lambdaParams = lambdaParams.Concat(new ParameterExpression[] { Expression.Parameter(typeof(bool)), Expression.Parameter(typeof(bool)) }).ToArray();
+                MethodInfo method = GetType().GetMethod("RunWithOutputConfig");
+                methodCall = Expression.Call(Expression.Constant(this), method, array, lambdaParams[nbInputs], lambdaParams[nbInputs + 1]);
+            }
+            else
+            {
+                MethodInfo method = GetType().GetMethod("Run");
+                methodCall = Expression.Call(Expression.Constant(this), method, array);
+            }
+
+            return methodCall;
+        }
+
+        /*******************************************/
+
+        protected virtual ExcelFunctionAttribute GetFunctionAttribute()
+        {
+            int limit = 254;
+            string description = Caller.Description;
+            if (description.Length >= limit)
+                description = description.Substring(0, limit - 1);
+            return new ExcelFunctionAttribute()
+            {
+                Name = Function,
+                Description = description,
+                Category = "BHoM." + Caller.Category,
+                IsMacroType = true
+            };
+        }
+
+        /*******************************************/
+
+        protected virtual List<ExcelArgumentAttribute> GetArgumentAttributes(List<ParamInfo> rawParams)
+        {
+            List<ExcelArgumentAttribute> argAttrs = rawParams.Select(p =>
+            {
+                string name = p.HasDefaultValue ? $"[{p.Name}]" : p.Name;
+                string postfix = string.Empty;
+                if (p.HasDefaultValue)
+                {
+                    postfix += " [default: " +
+                    (p.DefaultValue is string
+                        ? $"\"{p.DefaultValue}\""
+                        : p.DefaultValue == null
+                            ? "null"
+                            : p.DefaultValue.ToString()
+                    ) + "]";
+                }
+
+                int limit = 253 - name.Length;
+                string desc = p.Description + postfix;
+
+                if (desc.Length >= limit)
+                    desc = p.Description.Substring(limit - postfix.Length) + postfix;
+
+                return new ExcelArgumentAttribute() { Name = name, Description = desc };
+            }).ToList();
+
+            if (argAttrs.Count() > 0)
+            {
+                int nbFullName = argAttrs.Count;
+                string argstring = argAttrs.Select(item => item.Name).Aggregate((a, b) => $"{a}, {b}");
+                while (argstring.Length >= 254)
+                {
+                    nbFullName--;
+                    ExcelArgumentAttribute arg = argAttrs[nbFullName];
+                    bool isOptional = arg.Name.StartsWith("[");
+
+                    arg.Description = "Full name: " + arg.Name + ". " + arg.Description;
+                    arg.Name = string.Concat(arg.Name.Where(x => char.IsUpper(x)));
+                    if (isOptional)
+                        arg.Name = "[" + arg.Name + "]";
+
+                    argstring = argAttrs.Select(item => item.Name).Aggregate((a, b) => $"{a}, {b}");
+                }
+            }
+
+            return argAttrs;
+        }
+
+        /*******************************************/
+    }
+}
+
+

--- a/Excel_UI/Components/oM/CreateCustom.cs
+++ b/Excel_UI/Components/oM/CreateCustom.cs
@@ -29,6 +29,10 @@ using BH.Engine.Reflection;
 using Microsoft.Office.Core;
 using System.Collections.Generic;
 using BH.UI.Base.Components;
+using System.Linq.Expressions;
+using BH.oM.UI;
+using System.Reflection;
+using ExcelDna.Integration;
 
 namespace BH.UI.Excel.Components
 {
@@ -44,13 +48,88 @@ namespace BH.UI.Excel.Components
 
 
         /*******************************************/
-        /**** Methods                           ****/
+        /**** Override Methods                  ****/
         /*******************************************/
 
         public override string GetName()
         {
             return  "Create.CustomObject";
         }
+
+        /*******************************************/
+
+        protected override MethodCallExpression GetMethodCall(ref List<ParamInfo> inputs, ref ParameterExpression[] lambdaParams)
+        {
+            int nbInputs = Caller.InputParams.Count;
+            NewArrayExpression array = Expression.NewArrayInit(typeof(object), lambdaParams);
+
+            List<ParamInfo> extraInputs = new List<ParamInfo>
+            {
+                new ParamInfo { DataType = typeof(object), DefaultValue = null, HasDefaultValue = true, IsRequired = false, Name = "_inputTypes", Description = "Force the input values to be of the given types." },
+            };
+
+            inputs.AddRange(extraInputs);
+            lambdaParams = lambdaParams.Concat(new ParameterExpression[] { Expression.Parameter(typeof(object)) }).ToArray();
+            MethodInfo method = GetType().GetMethod("RunWithForcedTypes");
+
+            return Expression.Call(Expression.Constant(this), method, array, lambdaParams[nbInputs]);
+        }
+
+        /*******************************************/
+        /**** Methods                           ****/
+        /*******************************************/
+
+        public object RunWithForcedTypes(object[] inputs, object forcedTypes = null)
+        {
+            if (m_DataAccessor != null && forcedTypes != null && inputs != null && inputs.Length >= 2 && !(forcedTypes is ExcelMissing))
+            {
+                m_DataAccessor.SetInputs(new List<object> { inputs[1], forcedTypes }, new List<object> { new List<object>(), new List<Type>() });
+                List<object> objects = m_DataAccessor.GetDataList<object>(0);
+                List<Type> types = m_DataAccessor.GetDataList<Type>(1);
+
+                m_DataAccessor.SetInputs(objects, objects.Select(x => null as object).ToList());
+
+                for (int i = 0; i < Math.Min(Caller.InputParams.Count, types.Count); i++)
+                {
+
+                    if (types[i] != null && objects[i] != null)
+                    {
+                        Type type = types[i];
+                        if (!m_GetDataItemAccessors.ContainsKey(type))
+                            m_GetDataItemAccessors[type] = GetType().GetMethod("CallGetDataItem").MakeGenericMethod(new Type[] { type })?.ToFunc();
+
+                        Func<object[], object> getDataItem = m_GetDataItemAccessors[type];
+                        if (getDataItem != null)
+                        {
+                            object result = getDataItem(new object[] { m_DataAccessor, i });
+                            if (result != null)
+                                objects[i] = result;
+                        }
+                    }
+                }
+
+                inputs[1] = objects;
+            }
+
+            return Run(inputs);
+        }
+
+        /*******************************************/
+
+        public static object CallGetDataItem<T>(FormulaDataAccessor accessor, int index)
+        {
+            if (accessor != null)
+                return accessor.GetDataItem<T>(index);
+            else
+                return null;
+        }
+
+
+        /*******************************************/
+        /**** Private Fields                    ****/
+        /*******************************************/
+
+        protected static Dictionary<Type, Func<object[], object>> m_GetDataItemAccessors = new Dictionary<Type, Func<object[], object>>();
 
         /*******************************************/
     }

--- a/Excel_UI/Components/oM/CreateCustom.cs
+++ b/Excel_UI/Components/oM/CreateCustom.cs
@@ -89,7 +89,7 @@ namespace BH.UI.Excel.Components
 
                 m_DataAccessor.SetInputs(objects, objects.Select(x => null as object).ToList());
 
-                for (int i = 0; i < Math.Min(Caller.InputParams.Count, types.Count); i++)
+                for (int i = 0; i < Math.Min(objects.Count, types.Count); i++)
                 {
 
                     if (types[i] != null && objects[i] != null)

--- a/Excel_UI/Excel_UI.csproj
+++ b/Excel_UI/Excel_UI.csproj
@@ -122,6 +122,7 @@
     <Compile Include="Addin\AddIn_Objects.cs" />
     <Compile Include="Addin\AddIn_OpenClose.cs" />
     <Compile Include="Addin\AddIn.cs" />
+    <Compile Include="Caller\CallerFormula_MethodCall.cs" />
     <Compile Include="Components\Engine\GetEvents.cs" />
     <Compile Include="Ribbon\Ribbon_Condense.cs" />
     <Compile Include="Ribbon\Ribbon_Expand.cs" />


### PR DESCRIPTION

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #289 

This PR adds the ability to force property types on CreateCustom by modifying the code in two separate steps (see two separate commits for details on code changes):

1. **Refactor GetExcelDelegate so it can be overridden**: This method is in charge of generating the excel formula from the BHoM method. This PR moves it from being a static method in the Addin itself to a virtual method in the  `CallerFormula` class. This way it can be overriden by each child caller formula. `GetExcelDelegate` was also a fairly long method with parts that would likely be common to all children and a section that was already conditional to the type of caller. So I have extracted teh conditional part into a new method called `GetMethodCall`.
2. **Override GetMethodCall in CreateCustom**: This is where we add the extra input that enforces the property types. 


### Test files
https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/Excel_Toolkit/%23289-ForcedTypesOnCreateCustom?csf=1&web=1&e=19k9Ff

This file makes sure that 
- This PR doesn't break existing `Create.Custom` formulas (i.e. without the `forcedTypes` input)
- The property types can be enforced correctly
- It is possible to enforce only some of the property types.

