### PR TITLE
Making sure the in-cell formulas are versioned as well

### DIFF
--- a/Excel_UI/Excel_UI.csproj
+++ b/Excel_UI/Excel_UI.csproj
@@ -111,6 +111,10 @@
       <HintPath>C:\ProgramData\BHoM\Assemblies\UI_oM.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="Versioning_oM">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Versioning_oM.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Addin\AddIn_BackwardCompatibility.cs" />


### PR DESCRIPTION
  
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #285

While versioning was happening correctly on the loaded BHoM components, it was not applying the versioning on existing formulas stored in the cells (see additional comments if that sentence doesn't make sense to you). 

This PR fixes versioning issue by replacing all the old formulas found in any cell with the new ones. 

I would have liked to find a solution that would fix the problem on existing Excel files BUT figuring out the formula signature from the json had too many variations depending on the component type. After attempting that solution for a while, I couldn't avoid the duplication of code and the risk of missing edge cases.

So I decided to go for a much simpler solution where I save the formula at the same time I save the component in the hidden sheet. This results in a much simpler and robust code but sadly only fixing the bug for sheets saved after this PR. Excel not being used too much so far, I think this is a reasonable compromise though. The old spreadsheets also only need to be fixed once and saved and will work fine after that.

### Test files
https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/Excel_Toolkit/%23285-FormulaVersioning?csf=1&web=1&e=T6QLfL

Only `Query.Revit.InfoString?by_String` will still give a `#NAME` error because that component was deleted without replacement (as you can see at the bottom of the new versioning report).

Note this file was manufactured by 
- creating it in 4.0, 
- adding the old formulas info in the hidden sheet while the BHoM was deactivated (so no attempt to upgrade the file)


### Additional comments
For those that need clarification: 

The BHoM components are registered with Excel as new formulas. Once registered, those are treated as any other formula and don't need any support from the BHoM. The registration of the component using withing the need to be registered every time Excel is opened. So we stored the definition of those components in a hidden spreadsheet, load them when opening the file, version them if needed and register them with Excel. 

The formulas, are purely handled by Excel and will just work as long as the corresponding component was registered so the BHoM never manipulates them directly. The signature of a component will change once updated though. So the formula signature will change as well. For example: 

Old version: `=Query.ModelLaundry.IsPlanar?by_IElement1D_Double(A4)`
New version: `=Query.Spatial.IsPlanar?by_IElement1D_Double(A4)`

So the old formula will still search for the old component that doesn't exist anymore. This is where Excel gives us the `#NAME` error in the cell. 