### PR TITLE
Excel_Toolkit: Do not include empty cells when condensing a list

### DIFF
--- a/Excel_UI/Ribbon/Ribbon_Condense.cs
+++ b/Excel_UI/Ribbon/Ribbon_Condense.cs
@@ -53,7 +53,7 @@ namespace BH.UI.Excel.Addin
         [ExcelFunction(Name = "BHoM.Condense", Description = "Take a group of cells and store their content as a list in a single cell.", Category = "UI")]
         public static object Condense(object[] items)
         {
-            items = AddIn.FromExcel(items);
+            items = AddIn.FromExcel(items.Where(x => !(x is ExcelEmpty)).ToArray());
             return AddIn.ToExcel(items.ToList());
         }
 


### PR DESCRIPTION
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #284

See issue


### Test files
https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/Excel_Toolkit/%23284-CondenseEmptyCellsBug?csf=1&web=1&e=faeFe5

Before this PR, it results in something similar to what is shown in the issue.
With the fix, only non-empty cells are included in the condensed list:

![image](https://user-images.githubusercontent.com/16853390/118232923-d465dd00-b4c3-11eb-8d3a-f56771e123b4.png)

