### PR TITLE
Force AddIn to clean after itself when excel is exited

### DIFF
--- a/Excel_UI/Addin/AddIn.cs
+++ b/Excel_UI/Addin/AddIn.cs
@@ -41,9 +41,18 @@ namespace BH.UI.Excel
 
         public static Dictionary<string, CallerFormula> CallerShells { get; private set; } = new Dictionary<string, CallerFormula>();
 
+        public static AddIn Instance { get; private set; } = null;
+
 
         /*******************************************/
         /**** Constructors                      ****/
+        /*******************************************/
+
+        public AddIn()
+        {
+            Instance = this;
+        }
+
         /*******************************************/
 
         static AddIn()

--- a/Excel_UI/Ribbon/Ribbon.cs
+++ b/Excel_UI/Ribbon/Ribbon.cs
@@ -65,6 +65,17 @@ namespace BH.UI.Excel.Addin
             return ribbonxml;
         }
 
+        /*******************************************/
+
+        public override void OnBeginShutdown(ref Array custom)
+        {
+            AddIn addIn = AddIn.Instance;
+            if (addIn != null)
+                addIn.AutoClose();
+
+            base.OnBeginShutdown(ref custom);
+        }
+
 
         /*******************************************/
         /**** Methods                           ****/


### PR DESCRIPTION
  
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #233

It appears that ExcelDNA intellisenseServer is causing Excel to crash if not uninstalled prior closing. 
`IExcelAddIn` interface exposes a `AutoClose()` method. Unfortunately, this method is only called if the add-in is disabled during execution, not if Excel is exited. 
Thankfully, the ExcelDNA Ribbon class exposes a `OnBeginShutdown` method that we can override to make sure that `AutoClose()` is called on exiting Excel.


### Test files
Any file that cause excel to crash on exit can be used to test here. If you don't have any, you can use this one: https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/Excel_Toolkit/%23233-CrashOnExit?csf=1&web=1&e=UJXhLg
