### PR TITLE
Fix internalise bug on spill arrays

### DIFF
--- a/Excel_UI/Addin/AddIn_Internalise.cs
+++ b/Excel_UI/Addin/AddIn_Internalise.cs
@@ -66,7 +66,7 @@ namespace BH.UI.Excel
                         m_InternalisedData[id] = item;
 
                     // Replace cell formula with value
-                    ExcelAsyncUtil.QueueAsMacro(() => { cell.Formula = cell.Value; });
+                    ExcelAsyncUtil.QueueAsMacro(() => { cell.Formula = value; });
                 }
             }
             


### PR DESCRIPTION

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #315

The internalise function was replacing the formula of each cell with its string representation in order. This means that, as soon as the first cell of an expanded array was replaced, all the other cells would loose their value (since they don't contain a formula themselves). To fix this, we are now using the cached value of each cell. 


### Test files
https://burohappold.sharepoint.com/:f:/s/BHoM/EoFSYhhfB7VIo83fGEiQZksBx-GMQJ2upK1nbYfLvpYHIQ?e=Nui359

