### PR TITLE
Typo in Internalise data button description

### DIFF
--- a/Excel_UI/Ribbon/Ribbon.cs
+++ b/Excel_UI/Ribbon/Ribbon.cs
@@ -51,7 +51,7 @@ namespace BH.UI.Excel.Addin
             <group id='ui' label='UI'>
                 <button id='expand' onAction='RunExpand' label='Expand list' imageMso='OutlineExpandAll' supertip='Take a list stored in a single cell and expand over multiple cells (one cell per item in the list).'/>
                 <button id='condense' onAction='RunCondense' label='Condense cells' imageMso='CollapseAll' supertip='Take a group of cells and store their content as a list in a single cell.'/>
-                <button id='internalise' onAction='Internalise' label='Internalise data' imageMso='RecordsSaveRecord' supertip='Save the value of the selected cells so it will stil lbe available when the file is reopened.' />
+                <button id='internalise' onAction='Internalise' label='Internalise data' imageMso='RecordsSaveRecord' supertip='Save the value of the selected cells so it will still be available when the file is reopened.' />
             </group>
             <group id='help' label='Help'>
                 <button id='xlwiki' onAction='OpenLink' size='large' label='BHoM Excel Wiki' imageMso='Help' tag='https://github.com/BHoM/Excel_Toolkit/wiki' supertip='Go to the BHoM Excel plugin wiki to view help documentation relating to this plugin.' />

--- a/Excel_UI/Ribbon/Ribbon.cs
+++ b/Excel_UI/Ribbon/Ribbon.cs
@@ -51,7 +51,7 @@ namespace BH.UI.Excel.Addin
             <group id='ui' label='UI'>
                 <button id='expand' onAction='RunExpand' label='Expand list' imageMso='OutlineExpandAll' supertip='Take a list stored in a single cell and expand over multiple cells (one cell per item in the list).'/>
                 <button id='condense' onAction='RunCondense' label='Condense cells' imageMso='CollapseAll' supertip='Take a group of cells and store their content as a list in a single cell.'/>
-                <button id='internalise' onAction='Internalise' label='Internalise data' imageMso='RecordsSaveRecord' supertip='Save the value of the selected cells so it will still be available when the file is reopened.' />
+                <button id='internalise' onAction='Internalise' label='Internalise data' imageMso='RecordsSaveRecord' supertip='Save the value of the selected cells so that the values will be available when the file is reopened.' />
             </group>
             <group id='help' label='Help'>
                 <button id='xlwiki' onAction='OpenLink' size='large' label='BHoM Excel Wiki' imageMso='Help' tag='https://github.com/BHoM/Excel_Toolkit/wiki' supertip='Go to the BHoM Excel plugin wiki to view help documentation relating to this plugin.' />


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #352
When hovering over the 'Internalise data' button in the excel bhom UI ribbon, the description of the button contains a typo. Currently says, 'Save the value of the selected cells so it will stil lbe available when the file is reopened.' Needs to be changed to 'Save the value of the selected cells so it will still be available when the file is reopened.'


### Test files
None


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- `GetCustomUI()` - Typo addressed

### Additional comments
<!-- As required -->