### PR TITLE
Set ProjectIdEvent with FileId

### DIFF
--- a/Excel_UI/Caller/CallerFormula_Run.cs
+++ b/Excel_UI/Caller/CallerFormula_Run.cs
@@ -58,7 +58,7 @@ namespace BH.UI.Excel.Templates
             // Log usage
             Application app = ExcelDnaUtil.Application as Application;
             Workbook workbook = app.ActiveWorkbook;
-            SetProjectID(workbook);
+            SetProjectID(workbook, AddIn.WorkbookId(workbook));
             Engine.UI.Compute.LogUsage("Excel", app?.Version, InstanceId, Caller.GetType().Name, Caller.SelectedItem, Engine.Base.Query.CurrentEvents(), AddIn.WorkbookId(workbook), workbook.FullName);
 
             // Return result
@@ -84,7 +84,7 @@ namespace BH.UI.Excel.Templates
 
         /*******************************************/
 
-        private static void SetProjectID(Workbook workbook)
+        private static void SetProjectID(Workbook workbook, string fileID)
         {
             string projectId = workbook.Title;
 
@@ -93,7 +93,8 @@ namespace BH.UI.Excel.Templates
                 BH.Engine.Base.Compute.RecordEvent(new ProjectIDEvent
                 {
                     Message = "The project ID for this file is now set to " + projectId,
-                    ProjectID = projectId
+                    ProjectID = projectId,
+                    FileID = fileID
                 });
             }
         }


### PR DESCRIPTION

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->
Analytics Pop-up should not appear if Excel's Info --> Title property is filled out prior to BHoM method call. 

Closes #367 

<!-- Add short description of what has been fixed -->
Project ID Event is set with appropriate file id to allow LINQ filtering to collect the event from other logged events.
Project Id gets set before execution of pop-up window if project information project number is set.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Added FileId to ProjectIDEvent

### Additional comments
<!-- As required -->