### PR TITLE
Persist ProjectID Via Worksheet Method

### DIFF
--- a/Excel_UI/Caller/CallerFormula_Run.cs
+++ b/Excel_UI/Caller/CallerFormula_Run.cs
@@ -58,7 +58,6 @@ namespace BH.UI.Excel.Templates
             // Log usage
             Application app = ExcelDnaUtil.Application as Application;
             Workbook workbook = app.ActiveWorkbook;
-            SetProjectID(workbook, AddIn.WorkbookId(workbook));
             Engine.UI.Compute.LogUsage("Excel", app?.Version, InstanceId, Caller.GetType().Name, Caller.SelectedItem, Engine.Base.Query.CurrentEvents(), AddIn.WorkbookId(workbook), workbook.FullName);
 
             // Return result
@@ -83,21 +82,6 @@ namespace BH.UI.Excel.Templates
         }
 
         /*******************************************/
-
-        private static void SetProjectID(Workbook workbook, string fileID)
-        {
-            string projectId = workbook.Title;
-
-            if (!string.IsNullOrEmpty(projectId))
-            {
-                BH.Engine.Base.Compute.RecordEvent(new ProjectIDEvent
-                {
-                    Message = "The project ID for this file is now set to " + projectId,
-                    ProjectID = projectId,
-                    FileID = fileID
-                });
-            }
-        }
     }
 }
 


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #369 

<!-- Add short description of what has been fixed -->
Removed ability to persist projectID through stored value in workbook meta properties. Project Id must now be persisted via a `Compute.SetProjectID` method within the workbook. This brings the excel strategy in alignment with Grasshopper_UI.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- ProjectID is persisted via `Compute.SetProjectID` method within the workbook
