### PR TITLE
Fully Terminate Excel Process on Workbook Close

### DIFF
--- a/Excel_UI/Addin/AddIn_OpenClose.cs
+++ b/Excel_UI/Addin/AddIn_OpenClose.cs
@@ -148,8 +148,11 @@ namespace BH.UI.Excel
             try
             {
                 BH.UI.Base.Global.DocumentListener.OnDocumentClosing(workbook.FullName);
-                ClearObjects();
-            }
+                workbook.Application.Quit();
+                workbook = null;
+				ClearObjects();
+
+			}
             catch (Exception e)
             {
                 Debug.WriteLine(e.Message);


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #378

<!-- Add short description of what has been fixed -->
Excel process is terminated via `applicaiton.Quit()` on the workbook that called the `App_WorkbookClosed` method via the Close Event. Workbook is set to null.

### Test files
<!-- Link to test files to validate the proposed changes -->
Any excel file using the BHoM. 


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Modified Excel Add-In closing method to ensure full termination of process on workbook close 

### Additional comments
<!-- As required -->