### PR TITLE
Refactor Condense to accept 2D array 

### DIFF
--- a/Excel_UI/Addin/AddIn_Converts.cs
+++ b/Excel_UI/Addin/AddIn_Converts.cs
@@ -87,7 +87,7 @@ namespace BH.UI.Excel
         {
             try
             {
-                if (data == null)
+                if (data == null || data is ExcelEmpty)
                     return ExcelError.ExcelErrorNull;
                 else if (data.GetType().IsPrimitive || data is string || data is object[,])
                     return data;

--- a/Excel_UI/Addin/AddIn_Converts.cs
+++ b/Excel_UI/Addin/AddIn_Converts.cs
@@ -87,7 +87,7 @@ namespace BH.UI.Excel
         {
             try
             {
-                if (data == null || data is ExcelEmpty)
+                if (data == null || data is ExcelEmpty || data is ExcelError.ExcelErrorNull)
                     return ExcelError.ExcelErrorNull;
                 else if (data.GetType().IsPrimitive || data is string || data is object[,])
                     return data;

--- a/Excel_UI/Addin/AddIn_Converts.cs
+++ b/Excel_UI/Addin/AddIn_Converts.cs
@@ -155,13 +155,15 @@ namespace BH.UI.Excel
                 return new object[,] { { ExcelError.ExcelErrorNull } };
 
             int height = input.Count;
-            int width = input.Select(x => x.Count).Min();
+            int width = input.Select(x => x.Count).Max();
 
             object[,] evaluated = new object[height, width];
-            for (int i = 0; i < width; i++)
+            for (int i = 0; i < height; i++)  
             {
-                for (int j = 0; j < height; j++)
-                    evaluated[j, i] = ToExcel(input[j][i]);
+                for (int j = 0; j < input[i].Count; j++)
+                    evaluated[i, j] = ToExcel(input[i][j]);
+                for (int j = input[i].Count; j < width; j++)
+                    evaluated[i, j] = "";
             }
             return evaluated;
         }

--- a/Excel_UI/Addin/AddIn_Converts.cs
+++ b/Excel_UI/Addin/AddIn_Converts.cs
@@ -73,7 +73,7 @@ namespace BH.UI.Excel
             for (int i = 0; i < width; i++)
             {
                 for (int j = 0; j < height; j++)
-                    evaluated[j, i] = FromExcel(input[j, i]);
+                    evaluated[j, i] = FromExcel(input[j, i] is ExcelEmpty ? null : input[j, i]);
             }
             return evaluated;
         }

--- a/Excel_UI/Ribbon/Ribbon_Condense.cs
+++ b/Excel_UI/Ribbon/Ribbon_Condense.cs
@@ -51,10 +51,44 @@ namespace BH.UI.Excel.Addin
         /*******************************************/
 
         [ExcelFunction(Name = "BHoM.Condense", Description = "Take a group of cells and store their content as a list in a single cell.", Category = "UI")]
-        public static object Condense(object[] items)
+        public static object Condense(object item)
         {
-            items = AddIn.FromExcel(items.Where(x => !(x is ExcelEmpty)).ToArray());
-            return AddIn.ToExcel(items.ToList());
+            object result = new object();
+            if (item is object[,] array
+                && (array.GetLength(0) == 1 || array.GetLength(1) == 1))
+            {
+                var filteredItems = array
+                    .Cast<object>()
+                    .Where(x => !(x is ExcelEmpty))
+                    .ToArray();
+                result = AddIn.FromExcel(filteredItems).ToList();
+                return AddIn.ToExcel(result);
+            }
+
+            if (item is object[,] matrix
+                && matrix.GetLength(0) > 1
+                && matrix.GetLength(1) > 1)
+            {
+                var listResult = new List<object>();
+
+                for (int i = 0; i < matrix.GetLength(0); i++)
+                {
+                    List<object> row = Enumerable
+                        .Range(0, matrix.GetLength(1))
+                        .Select(x => matrix[i, x]).ToList();
+                    listResult.Add(AddIn.FromExcel(row));
+                }
+
+                result = AddIn.FromExcel(listResult);
+                return AddIn.ToExcel(result);
+            }
+
+            else
+            {
+                result = AddIn.FromExcel(item);
+                return AddIn.ToExcel(result);
+            }
+
         }
 
         /*******************************************/

--- a/Excel_UI/Ribbon/Ribbon_Condense.cs
+++ b/Excel_UI/Ribbon/Ribbon_Condense.cs
@@ -69,17 +69,17 @@ namespace BH.UI.Excel.Addin
                 && matrix.GetLength(0) > 1
                 && matrix.GetLength(1) > 1)
             {
-                var listResult = new List<object>();
+                List<List<object>> listResult = new List<List<object>>();
 
                 for (int i = 0; i < matrix.GetLength(0); i++)
                 {
                     List<object> row = Enumerable
                         .Range(0, matrix.GetLength(1))
-                        .Select(x => matrix[i, x]).ToList();
-                    listResult.Add(AddIn.FromExcel(row));
+                        .Select(x => AddIn.FromExcel(matrix[i, x])).ToList();
+                    listResult.Add(row);
                 }
 
-                result = AddIn.FromExcel(listResult);
+                result = listResult;
                 return AddIn.ToExcel(result);
             }
 

--- a/Excel_UI/Ribbon/Ribbon_Expand.cs
+++ b/Excel_UI/Ribbon/Ribbon_Expand.cs
@@ -51,7 +51,7 @@ namespace BH.UI.Excel.Addin
             item = AddIn.FromExcel(item);
             object[,] result;
 
-            if (item is IEnumerable array)
+            if (item is IEnumerable<object> array)
             {
                 List<object> content = array.Cast<object>().ToList();
                 if (content.All(x => x is IEnumerable<object>))

--- a/Excel_UI/Ribbon/Ribbon_Expand.cs
+++ b/Excel_UI/Ribbon/Ribbon_Expand.cs
@@ -53,7 +53,7 @@ namespace BH.UI.Excel.Addin
 
             if (item is IEnumerable array)
             {
-                List<object> content = array.OfType<object>().ToList();
+                List<object> content = array.Cast<object>().ToList();
                 if (content.All(x => x is IEnumerable<object>))
                 {
                     result = AddIn.ToExcel(content.OfType<IEnumerable>().Select(x => x.OfType<object>().ToList()).ToList());

--- a/Excel_UI/Ribbon/Ribbon_Expand.cs
+++ b/Excel_UI/Ribbon/Ribbon_Expand.cs
@@ -54,8 +54,11 @@ namespace BH.UI.Excel.Addin
             if (item is IEnumerable array)
             {
                 List<object> content = array.OfType<object>().ToList();
-                if (content.All(x => x is IEnumerable))
+                if (content.All(x => x is IEnumerable<object>))
+                {
                     result = AddIn.ToExcel(content.OfType<IEnumerable>().Select(x => x.OfType<object>().ToList()).ToList());
+                }
+                    
                 else
                 {
                     int count = content.Count();

--- a/Excel_UI/Ribbon/Ribbon_Expand.cs
+++ b/Excel_UI/Ribbon/Ribbon_Expand.cs
@@ -52,10 +52,11 @@ namespace BH.UI.Excel.Addin
 
             if (item is IEnumerable)
             {
-                try
-                {                    
-                    var nestedList = ((IEnumerable)item).Cast<List<object>>().ToArray();
+                 
+                var nestedList = item as List<object>[];
 
+                if(nestedList != null)
+                {
                     int height = nestedList.Length;
                     int width = nestedList[0].Count;
 
@@ -71,7 +72,7 @@ namespace BH.UI.Excel.Addin
                         for(int j = 0; j < nestedList[i].Count; j++) { result[i,j] = nestedList[i][j]; }
                     }
                 }
-                catch
+                else
                 {
                     result = ((IEnumerable)item).Cast<object>().ToArray();
                 }                

--- a/Excel_UI/Ribbon/Ribbon_Expand.cs
+++ b/Excel_UI/Ribbon/Ribbon_Expand.cs
@@ -20,18 +20,11 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
  */
 
-using BH.UI.Excel.Templates;
 using ExcelDna.Integration;
 using ExcelDna.Integration.CustomUI;
-using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Drawing;
 using System.Linq;
-using System.Runtime.InteropServices;
-using System.Text;
-using System.Threading.Tasks;
-using System.Xml;
 
 namespace BH.UI.Excel.Addin
 {
@@ -60,8 +53,7 @@ namespace BH.UI.Excel.Addin
             if (item is IEnumerable)
             {
                 try
-                {
-                    
+                {                    
                     var nestedList = ((IEnumerable)item).Cast<List<object>>().ToArray();
 
                     int height = nestedList.Length;

--- a/Excel_UI/Ribbon/Ribbon_Expand.cs
+++ b/Excel_UI/Ribbon/Ribbon_Expand.cs
@@ -46,7 +46,7 @@ namespace BH.UI.Excel.Addin
         /*******************************************/
 
         [ExcelFunction(Name = "BHoM.Expand", Description = "Take a list stored in a single cell and expand over multiple cells (one cell per item in the list).", Category = "UI")]
-        public static object Expand(object item, bool transpose = false)
+        public static object Expand(object item, bool transpose = false, bool onlyExpandFirstDimension = false)
         {
             item = AddIn.FromExcel(item);
             object[,] result;
@@ -54,11 +54,10 @@ namespace BH.UI.Excel.Addin
             if (item is IEnumerable<object> array)
             {
                 List<object> content = array.Cast<object>().ToList();
-                if (content.All(x => x is IEnumerable<object>))
+                if (!onlyExpandFirstDimension && content.All(x => x is IEnumerable<object>))
                 {
                     result = AddIn.ToExcel(content.OfType<IEnumerable>().Select(x => x.OfType<object>().ToList()).ToList());
-                }
-                    
+                }  
                 else
                 {
                     int count = content.Count();


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->
It is now possible to condense 2D array into a cell. 

<!-- Add short description of what has been fixed -->
Condensed matrix is stored as List<List<row>>. Condense list/object remains unchanged.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->

- Modified **FromExcel(object[] input)** to handle null errors.
- Updated **Condense(object[] items)** to **Condense(object item)** to avoid early casting issues.

@BHoMBot Check all
