### PR TITLE
Avoid loading all assemblies by using a pre-compiled menu data file

### DIFF
--- a/Excel_UI/BHoM_UI_Overrides/SelectorMenu_RibbonXml.cs
+++ b/Excel_UI/BHoM_UI_Overrides/SelectorMenu_RibbonXml.cs
@@ -66,7 +66,12 @@ namespace BH.UI.Excel.Templates
         public object GetItem(string id)
         {
             if (m_ItemLinks.ContainsKey(id))
-                return m_ItemLinks[id];
+            {
+                SearchItem searchItem = m_ItemLinks[id];
+                if (searchItem.Item == null && !string.IsNullOrEmpty(searchItem.Json))
+                    searchItem.Item = BH.Engine.Serialiser.Convert.FromJson(searchItem.Json);
+                return searchItem.Item;
+            }
             else
                 return null;
         }
@@ -83,14 +88,14 @@ namespace BH.UI.Excel.Templates
 
         /*******************************************/
 
-        protected override void AddTree(XmlElement menu, Tree<object> itemTree)
+        protected override void AddTree(XmlElement menu, Tree<SearchItem> itemTree)
         {
             AppendMenuTree(itemTree, menu);
         }
 
         /*******************************************/
 
-        private void AppendMenuTree(Tree<object> tree, XmlElement menu)
+        private void AppendMenuTree(Tree<SearchItem> tree, XmlElement menu)
         {
             XmlDocument document = menu.OwnerDocument;
             XmlElement element;
@@ -98,12 +103,12 @@ namespace BH.UI.Excel.Templates
             if (tree.Children.Count > 0)
             {
                 element = document.CreateElement("menu");
-                foreach (Tree<object> childTree in tree.Children.Values.OrderBy(x => x.Name))
+                foreach (Tree<SearchItem> childTree in tree.Children.Values.OrderBy(x => x.Name))
                     AppendMenuTree(childTree, element);
             }
             else
             {
-                object method = tree.Value;
+                SearchItem method = tree.Value;
                 element = document.CreateElement("button");
                 element.SetAttribute("onAction", "FillFormula");
                 string description = method.IDescription();
@@ -126,7 +131,7 @@ namespace BH.UI.Excel.Templates
         /**** Private Fields                    ****/
         /*******************************************/
 
-        private Dictionary<string, object> m_ItemLinks = new Dictionary<string, object>();
+        private Dictionary<string, SearchItem> m_ItemLinks = new Dictionary<string, SearchItem>();
 
         /*******************************************/
     }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
https://github.com/BHoM/BHoM_Engine/pull/3561
https://github.com/BHoM/BHoM_UI/pull/531

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

See https://github.com/BHoM/BHoM_UI/pull/531 for details.

Excel UI is using a custom override on the selector menu. So the changes applied to the BHoM UI also had to be applied here.

### Test files
Follow the testing procedure suggested in https://github.com/BHoM/BHoM_UI/pull/531

