### PR TITLE
Switch to byte arrays for icons to keep Excel_UI compatible with dotnet

### DIFF
--- a/Excel_UI/Properties/Resources.Designer.cs
+++ b/Excel_UI/Properties/Resources.Designer.cs
@@ -87,8 +87,8 @@ namespace BH.UI.Excel.Properties {
         /// </summary>
         internal static System.Drawing.Bitmap BHoM_Logo {
             get {
-                object obj = ResourceManager.GetObject("BHoM_Logo", resourceCulture);
-                return ((System.Drawing.Bitmap)(obj));
+                byte[] bytes = (byte[])ResourceManager.GetObject("BHoM_Logo", resourceCulture);
+                return new System.Drawing.Bitmap(new System.IO.MemoryStream(bytes));
             }
         }
     }

--- a/Excel_UI/Properties/Resources.resx
+++ b/Excel_UI/Properties/Resources.resx
@@ -119,6 +119,6 @@
   </resheader>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="BHoM_Logo" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>Resources\BHoM_Logo-48x48.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+    <value>Resources\BHoM_Logo-48x48.png;System.Byte[], mscorlib</value>
   </data>
 </root>


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Needs to be reviewed and merged with
https://github.com/BHoM/BHoM_UI/pull/554

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #437 

As per the issue's description, this allows Excel_UI to compile with `dotnet build` without breaking it by using `byte[]` for icons instead of Bitmaps. 

**Important**: To be reviewed and merged on only after the beta release. I don't want to inject framework changes this close to the end of the milestone.

@michaelhoehn , I have added you as reviewer for visibility but I don't expect you to review this since you will be gone by then. 


### Test files
Just make sure you can build Excel_UI with `dotnet build` and that it is still loading correctly in Excel.


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->